### PR TITLE
BRS-615 adding subArea UID

### DIFF
--- a/__tests__/global/data.json
+++ b/__tests__/global/data.json
@@ -3,8 +3,14 @@
     {
       "sk": "0041",
       "subAreas": [
-        "Maple Bay",
-        "Teapot Hill"
+        {
+          "name": "Maple Bay",
+          "id": "0087"
+        },
+        {
+          "name": "Teapot Hill",
+          "id": "0089"
+        }
       ],
       "pk": "park",
       "parkName": "Cultus Lake Park"
@@ -12,7 +18,10 @@
     {
       "sk": "6161",
       "subAreas": [
-        "Holt Creek"
+        {
+          "name": "Holt Creek",
+          "id": "0074"
+        }
       ],
       "pk": "park",
       "parkName": "Cowichan River Park"
@@ -20,11 +29,11 @@
   ],
   "SUBAREA_INFORMATION": [
     {
-      "sk": "Maple Bay",
-      "pk": "park::0041",
+      "sk": "0087",
+      "pk": "subarea::0041",
       "parkName": "Cultus Lake Park",
       "activities": [
-        "Boating",
+        "Frontcountry Camping",
         "Day Use"
       ],
       "orcs": 41,
@@ -33,10 +42,10 @@
   ],
   "SUBAREAS": [
     {
-      "pk": "park::0041",
-      "sk": "Maple Bay",
+      "pk": "0087",
+      "sk": "subarea::0041",
       "activities": [
-        "Boating",
+        "Frontcountry Camping",
         "Day Use"
       ],
       "parkName": "Cultus Lake Park",
@@ -44,8 +53,8 @@
       "subAreaName": "Maple Bay"
     },
     {
-      "pk": "park::0041",
-      "sk": "Teapot Hill",
+      "pk": "subarea::0041",
+      "sk": "0089",
       "activities": [
         "Day Use"
       ],
@@ -54,18 +63,18 @@
       "subAreaName": "Teapot Hill"
     },
     {
-      "pk": "park::6161",
-      "sk": "Holt Creek",
+      "pk": "subarea::6161",
+      "sk": "0074",
       "activities": [
         "Day Use"
       ],
-      "orcs": 41,
+      "orcs": "6161",
       "subAreaName": "Holt Creek"
     }
   ],
   "SUBAREA_ENTRIES": [
     {
-      "pk": "0041::Maple Bay::Day Use",
+      "pk": "0087::Day Use",
       "sk": "202204",
       "parkName": "Cultus Lake Park",
       "picnicRevenue": 2.5,
@@ -84,7 +93,7 @@
       "picnicRentals": 5
     },
     {
-      "pk": "0041::Maple Bay::Boating",
+      "pk": "0087::Frontcountry Camping",
       "sk": "202204",
       "parkName": "Cultus Lake Park",
       "picnicRevenue": 2.5,
@@ -105,28 +114,26 @@
   ],
   "CONFIG_ENTRIES": [
     {
-      "pk": "0041::Maple Bay::Day Use",
-      "sk": "config",
+      "pk": "config::0087",
+      "sk": "Day Use",
       "parkName": "Cultus Lake Park",
-      "pplCalculations": {
-        "vehicleModifier": 3.5,
-        "busModifier": 40
-      },
+      "attendanceVehicleModifier": 3.5,
+      "attendanceBusModifier": 40,
       "orcs": "0041",
       "subAreaName": "Maple Bay",
+      "subAreaId": "0087",
       "activity": "Day Use"
     },
     {
-      "pk": "0041::Maple Bay::Boating",
-      "sk": "config",
+      "pk": "config::0087",
+      "sk": "Frontcountry Camping",
       "parkName": "Cultus Lake Park",
-      "pplCalculations": {
-        "vehicleModifier": 3.5,
-        "busModifier": 40
-      },
+      "attendanceVehicleModifier": 3.5,
+      "attendanceBusModifier": 40,
       "subAreaName": "Maple Bay",
+      "subAreaId": "0087",
       "orcs": "0041",
-      "activity": "Day Use"
+      "activity": "Frontcountry Camping"
     }
   ]
 }

--- a/__tests__/global/data.json
+++ b/__tests__/global/data.json
@@ -30,7 +30,7 @@
   "SUBAREA_INFORMATION": [
     {
       "sk": "0087",
-      "pk": "subarea::0041",
+      "pk": "park::0041",
       "parkName": "Cultus Lake Park",
       "activities": [
         "Frontcountry Camping",
@@ -42,8 +42,8 @@
   ],
   "SUBAREAS": [
     {
-      "pk": "0087",
-      "sk": "subarea::0041",
+      "pk": "park::0041",
+      "sk": "0087",
       "activities": [
         "Frontcountry Camping",
         "Day Use"
@@ -53,7 +53,7 @@
       "subAreaName": "Maple Bay"
     },
     {
-      "pk": "subarea::0041",
+      "pk": "park::0041",
       "sk": "0089",
       "activities": [
         "Day Use"
@@ -63,7 +63,7 @@
       "subAreaName": "Teapot Hill"
     },
     {
-      "pk": "subarea::6161",
+      "pk": "park::6161",
       "sk": "0074",
       "activities": [
         "Day Use"
@@ -78,10 +78,8 @@
       "sk": "202204",
       "parkName": "Cultus Lake Park",
       "picnicRevenue": 2.5,
-      "pplCalculations": {
-        "vehicleModifier": 3.5,
-        "busModifier": 40
-      },
+      "attendanceVehicleModifier": 3.5,
+      "attendanceBusModifier": 40,
       "pplVehicleCount": 12,
       "subAreaName": "Maple Bay",
       "otherHotSpringsRevenue": 5.55,
@@ -97,10 +95,8 @@
       "sk": "202204",
       "parkName": "Cultus Lake Park",
       "picnicRevenue": 2.5,
-      "pplCalculations": {
-        "vehicleModifier": 3.5,
-        "busModifier": 40
-      },
+      "attendanceVehicleModifier": 3.5,
+      "attendanceBusModifier": 40,
       "pplVehicleCount": 12,
       "subAreaName": "Maple Bay",
       "otherHotSpringsRevenue": 5.55,

--- a/__tests__/park.test.js
+++ b/__tests__/park.test.js
@@ -64,7 +64,7 @@ describe('Pass Succeeds', () => {
     const response = await parkGET.handler({
       queryStringParameters: {
         orcs: PARKSLIST[0].sk,
-        subAreaName: specificSubAreas[0].subAreaName
+        subAreaId: specificSubAreas[0].sk
       }
     }, null);
 

--- a/__tests__/park.test.js
+++ b/__tests__/park.test.js
@@ -57,7 +57,7 @@ describe('Pass Succeeds', () => {
   test('Handler - 200 Receive park specific information', async () => {
     let specificSubAreas = [];
     for(const area of SUBAREAS) {
-      if (area.pk === "park::0041") {
+      if (area.pk === "subarea::0041") {
         specificSubAreas.push(area);
       }
     }

--- a/__tests__/park.test.js
+++ b/__tests__/park.test.js
@@ -57,7 +57,7 @@ describe('Pass Succeeds', () => {
   test('Handler - 200 Receive park specific information', async () => {
     let specificSubAreas = [];
     for(const area of SUBAREAS) {
-      if (area.pk === "subarea::0041") {
+      if (area.pk === "park::0041") {
         specificSubAreas.push(area);
       }
     }

--- a/__tests__/subarea.test.js
+++ b/__tests__/subarea.test.js
@@ -139,8 +139,8 @@ describe('Subarea Test', () => {
         },
         body: JSON.stringify({
           orcs: SUBAREA_ENTRIES[0].orcs,
-          subAreaName: SUBAREA_ENTRIES[0].subAreaName,
-          activity: SUBAREA_ENTRIES[0].pk.split("::")[2],
+          subAreaId: SUBAREA_ENTRIES[0].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[0].pk.split("::")[1],
           date: "2022" // Invalid
         })
       }, null);

--- a/__tests__/subarea.test.js
+++ b/__tests__/subarea.test.js
@@ -50,8 +50,8 @@ describe('Subarea Test', () => {
       {
         queryStringParameters: {
           orcs: SUBAREA_ENTRIES[0].orcs,
-          subAreaName: SUBAREA_ENTRIES[0].subAreaName,
-          activity: SUBAREA_ENTRIES[0].pk.split("::")[2],
+          subAreaId: SUBAREA_ENTRIES[0].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[0].pk.split("::")[1],
           date: SUBAREA_ENTRIES[0].sk
         }
       }, null);
@@ -76,8 +76,8 @@ describe('Subarea Test', () => {
         },
         body: JSON.stringify({
           orcs: SUBAREA_ENTRIES[0].orcs,
-          subAreaName: SUBAREA_ENTRIES[0].subAreaName,
-          activity: SUBAREA_ENTRIES[0].pk.split("::")[2],
+          subAreaId: SUBAREA_ENTRIES[0].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[0].pk.split("::")[1],
           date: "202201"
         })
       }, null);

--- a/lambda/park/GET/index.js
+++ b/lambda/park/GET/index.js
@@ -27,12 +27,12 @@ exports.handler = async (event, context) => {
     } else if (event.queryStringParameters?.orcs) {
       // Get me a list of this parks' subareas with activities details, including config details
       queryObj.ExpressionAttributeValues = {};
-      queryObj.ExpressionAttributeValues[':pk'] = { S: 'park::' + event.queryStringParameters?.orcs };
+      queryObj.ExpressionAttributeValues[':pk'] = { S: 'subarea::'+ event.queryStringParameters?.orcs };
       queryObj.KeyConditionExpression = 'pk =:pk';
 
-      if (event?.queryStringParameters?.subAreaName) {
-        // sk for month or a range
-        queryObj.ExpressionAttributeValues[':sk'] = { S: `${event.queryStringParameters?.subAreaName}` };
+      if (event?.queryStringParameters?.subAreaId) {
+        // get specific subarea by subAreaId
+        queryObj.ExpressionAttributeValues[':sk'] = { S: `${event.queryStringParameters?.subAreaId}` };
         queryObj.KeyConditionExpression += ' AND sk =:sk';
       }
 

--- a/lambda/park/GET/index.js
+++ b/lambda/park/GET/index.js
@@ -27,7 +27,7 @@ exports.handler = async (event, context) => {
     } else if (event.queryStringParameters?.orcs) {
       // Get me a list of this parks' subareas with activities details, including config details
       queryObj.ExpressionAttributeValues = {};
-      queryObj.ExpressionAttributeValues[':pk'] = { S: 'subarea::'+ event.queryStringParameters?.orcs };
+      queryObj.ExpressionAttributeValues[':pk'] = { S: 'park::'+ event.queryStringParameters?.orcs };
       queryObj.KeyConditionExpression = 'pk =:pk';
 
       if (event?.queryStringParameters?.subAreaId) {

--- a/lambda/subarea/GET/index.js
+++ b/lambda/subarea/GET/index.js
@@ -10,19 +10,17 @@ exports.handler = async (event, context) => {
   };
 
   try {
-    if (event?.queryStringParameters?.orcs
-        && event?.queryStringParameters?.subAreaName
+    if (event?.queryStringParameters?.subAreaId
         && event?.queryStringParameters?.activity
         && event?.queryStringParameters?.date) {
       // Get the subarea details
-      const orcs = event.queryStringParameters?.orcs;
-      const subAreaName = event.queryStringParameters?.subAreaName;
+      const subAreaId = event.queryStringParameters?.subAreaId;
       const activity = event.queryStringParameters?.activity;
       const date = event.queryStringParameters?.date;
 
       // Get me a list of this park's subarea details
       queryObj.ExpressionAttributeValues = {};
-      queryObj.ExpressionAttributeValues[':pk'] = { S: `${orcs}::${subAreaName}::${activity}` };
+      queryObj.ExpressionAttributeValues[':pk'] = { S: `${subAreaId}::${activity}` };
       queryObj.ExpressionAttributeValues[':sk'] = { S: `${date}` };
 
       queryObj.KeyConditionExpression = 'pk =:pk AND sk =:sk';
@@ -35,8 +33,8 @@ exports.handler = async (event, context) => {
       let configObj = {
         TableName: TABLE_NAME,
         ExpressionAttributeValues: {
-          ':pk':  { S: `${orcs}::${subAreaName}::${activity}` },
-          ':sk': { S: 'config' }
+          ':pk':  { S: `config::${subAreaId}` },
+          ':sk': { S: activity }
         },
         KeyConditionExpression: 'pk =:pk AND sk =:sk'
       };

--- a/lambda/subarea/POST/index.js
+++ b/lambda/subarea/POST/index.js
@@ -23,18 +23,18 @@ exports.handler = async (event, context) => {
 async function handleActivity(body, context) {
   // Set pk/sk
   try {
-    if (!body.orcs || !body.subAreaName || !body.activity || !body.date) {
+    if (!body.subAreaId || !body.activity || !body.date) {
       throw "Invalid request.";
     }
 
-    const pk = `${body.orcs}::${body.subAreaName}::${body.activity}`;
+    const pk = `${body.subAreaId}::${body.activity}`;
 
     // Get config to attach to activity
     const configObj = {
       TableName: TABLE_NAME,
       ExpressionAttributeValues: {
-        ":pk": { S: pk },
-        ":sk": { S: "config" },
+        ":pk": { S: `config::${body.subAreaId}`},
+        ":sk": { S: body.activity },
       },
       KeyConditionExpression: "pk =:pk AND sk =:sk",
     };
@@ -69,12 +69,12 @@ async function handleConfig(body, context) {
   try {
     // Set pk/sk
 
-    if (!body.orcs || !body.subAreaName || !body.activity) {
+    if (!body.subAreaId || !body.activity) {
       throw "Invalid request.";
     }
 
-    body["pk"] = `${body.orcs}::${body.subAreaName}::${body.activity}`;
-    body["sk"] = "config";
+    body["pk"] = `config::${body.subAreaId}`;
+    body["sk"] = body.activity;
 
     const newObject = AWS.DynamoDB.Converter.marshall(body);
 

--- a/miscellaneous/Example Subareas/Backcountry Cabins.json
+++ b/miscellaneous/Example Subareas/Backcountry Cabins.json
@@ -1,8 +1,9 @@
 {
-  "pk": "0005::Naiset Cabins::Backcountry Cabins",
+  "pk": "0271::Backcountry Cabins",
   "sk": "202201",
   "parkName": "Mount Assiniboine",
   "subAreaName": "Naiset Cabins",
+  "subAreaId":"0271",
   "orcs": "0005",
   "peopleAdult": 0,
   "peopleChild": 0,

--- a/miscellaneous/Example Subareas/Backcountry Camping.json
+++ b/miscellaneous/Example Subareas/Backcountry Camping.json
@@ -1,8 +1,9 @@
 {
-  "pk": "0001::Della Falls::Backcountry Camping",
+  "pk": "0404::Backcountry Camping",
   "sk": "202201",
   "parkName": "Strathcona Park",
   "subAreaName": "Della Falls",
+  "subAreaId": "0404",
   "orcs": "0001",
   "people": 0,
   "grossCampingRevenue": 0,

--- a/miscellaneous/Example Subareas/Boating.json
+++ b/miscellaneous/Example Subareas/Boating.json
@@ -1,8 +1,9 @@
 {
-  "pk": "0365::Halkett Bay::Boating",
+  "pk": "0173::Boating",
   "sk": "202201",
   "parkName": "Halkett Bay Marine Park",
   "subAreaName": "Halkett Bay",
+  "subAreaId": "0173",
   "orcs": "0365",
   "boatAttendanceNightsOnDock": 0,
   "boatAttendanceNightsOnBouys": 0,

--- a/miscellaneous/Example Subareas/Day Use.json
+++ b/miscellaneous/Example Subareas/Day Use.json
@@ -1,8 +1,9 @@
 {
-  "pk": "0001::Bedwell::Day Use",
+  "pk": "0421::Bedwell::Day Use",
   "sk": "202201",
   "parkName": "Strathcona Park",
   "subAreaName": "Strathcona Corridor",
+  "subAreaId": "0421",
   "orcs": "0001",
   "peopleAndVehiclesTrail": 0,
   "peopleAndVehiclesVehicle": 0,

--- a/miscellaneous/Example Subareas/Frontcountry Cabins.json
+++ b/miscellaneous/Example Subareas/Frontcountry Cabins.json
@@ -1,8 +1,9 @@
 {
-  "pk": "0041::Maple Bay Cabins::Frontcountry Cabins",
+  "pk": "0086::Frontcountry Cabins",
   "sk": "202201",
   "parkName": "Cultus Lake Park",
   "subAreaName": "Maple Bay Cabins",
+  "subAreaId": "0086",
   "orcs": "0041",
   "totalAttendanceParties": 4,
   "revenueGrossCamping": 5.55,

--- a/miscellaneous/Example Subareas/Frontcountry Camping.json
+++ b/miscellaneous/Example Subareas/Frontcountry Camping.json
@@ -1,5 +1,5 @@
 {
-  "pk": "0001::Bedwell::Frontcountry Camping",
+  "pk": "0421::Frontcountry Camping",
   "sk": "202201",
   "campingPartyNightsAttendanceSocial": 0,
   "parkName": "Strathcona Park",
@@ -8,6 +8,7 @@
   "otherRevenueGrossSani": 0,
   "secondCarsAttendanceSocial": 0,
   "subAreaName": "Bedwell",
+  "subAreaId": "0421",
   "secondCarsAttendanceSenior": 0,
   "campingPartyNightsAttendanceSenior": 0,
   "otherRevenueShower": 0,

--- a/miscellaneous/Example Subareas/Group Camping.json
+++ b/miscellaneous/Example Subareas/Group Camping.json
@@ -1,8 +1,9 @@
 {
-  "pk": "6161::Stoltz Pool::Group Camping",
+  "pk": "0077::Group Camping",
   "sk": "202201",
   "parkName": "Cowichan River Park",
   "subAreaName": "Stoltz Pool",
+  "subAreaId": "0077",
   "orcs": "6161",
   "standardRateGroupsTotalPeopleStandard": 0,
   "standardRateGroupsTotalPeopleAdults": 0,

--- a/tools/convertParksSheet.js
+++ b/tools/convertParksSheet.js
@@ -129,7 +129,7 @@ async function doMigration() {
 
       // 2. Add the subarea /w activities record
       const parkSubAreaRecord = {
-        pk: AWS.DynamoDB.Converter.input('subarea::'+ parkRecord.sk.S),
+        pk: AWS.DynamoDB.Converter.input('park::'+ parkRecord.sk.S),
         sk: AWS.DynamoDB.Converter.input(subAreaId),
         region: AWS.DynamoDB.Converter.input(row['Region']),
         section: AWS.DynamoDB.Converter.input(row['Section']),
@@ -142,7 +142,7 @@ async function doMigration() {
       };
       await putItem(parkSubAreaRecord, true);
 
-      // 3. For each activity, add the config for that orc::subarea::activity
+      // 3. For each activity, add the config for that subAreaId::activity
       for (const activity of activities) {
         let activityRecord = {
           pk: {S: 'config::'+ subAreaId},

--- a/tools/convertParksSheet.js
+++ b/tools/convertParksSheet.js
@@ -59,6 +59,10 @@ const schema = {
   'Region': {
     prop: 'Region',
     type: String
+  },
+  'Sub Area ID': {
+    prop: 'Sub Area ID',
+    type: String
   }
 }
 
@@ -95,6 +99,12 @@ async function doMigration() {
       // string is the subarea name itself.
       const subAreaNameSplitContent = row['Park Sub Area'].split(" - ");
       const subAreaName = subAreaNameSplitContent[subAreaNameSplitContent.length - 1];
+      const subAreaId = row['Sub Area ID'];
+
+      const subAreaObj = {
+        id: subAreaId,
+        name: subAreaName
+      }
 
       // 1. Add the park record
       const parkRecord = {
@@ -102,18 +112,25 @@ async function doMigration() {
         sk: AWS.DynamoDB.Converter.input(row['ORCS Number']),
         parkName: AWS.DynamoDB.Converter.input(row['Park']),
         subAreas: {
-          SS: [subAreaName],
+          'L': [
+            {
+              'M':{
+                'id': {'S': subAreaId},
+                'name': {'S': subAreaName}
+              }
+            }
+          ]
         }
       };
       if (await putItem(parkRecord) == false) {
         // Record already existed, lets add the subarea to the object.
-        await updateItem(parkRecord, subAreaName);
+        await updateItem(parkRecord, subAreaObj);
       }
 
       // 2. Add the subarea /w activities record
       const parkSubAreaRecord = {
-        pk: AWS.DynamoDB.Converter.input('park::' + parkRecord.sk.S),
-        sk: AWS.DynamoDB.Converter.input(subAreaName),
+        pk: AWS.DynamoDB.Converter.input('subarea::'+ parkRecord.sk.S),
+        sk: AWS.DynamoDB.Converter.input(subAreaId),
         region: AWS.DynamoDB.Converter.input(row['Region']),
         section: AWS.DynamoDB.Converter.input(row['Section']),
         managementArea: AWS.DynamoDB.Converter.input(row['Management Area']),
@@ -128,10 +145,11 @@ async function doMigration() {
       // 3. For each activity, add the config for that orc::subarea::activity
       for (const activity of activities) {
         let activityRecord = {
-          pk: AWS.DynamoDB.Converter.input(parkRecord.sk.S + '::' + subAreaName + '::' + activity),
-          sk: { S: 'config' },
+          pk: {S: 'config::'+ subAreaId},
+          sk: AWS.DynamoDB.Converter.input(activity),
           parkName: AWS.DynamoDB.Converter.input(parkRecord.parkName.S),
           orcs: AWS.DynamoDB.Converter.input(parkRecord.sk.S),
+          subAreaId: AWS.DynamoDB.Converter.input(subAreaId),
           subAreaName: AWS.DynamoDB.Converter.input(subAreaName)
         };
 
@@ -152,7 +170,6 @@ async function doMigration() {
           } break;
         }
 
-        // console.log("activityRecord:", activityRecord);
         await putItem(activityRecord, true);
       }
     }
@@ -167,10 +184,18 @@ async function updateItem(record, subarea) {
       pk: record.pk,
       sk: record.sk
     },
-    UpdateExpression: 'ADD subAreas :subAreas',
+    UpdateExpression: 'SET #subAreas = list_append(#subAreas, :subAreas)',
+    ExpressionAttributeNames: {
+      '#subAreas': 'subAreas'
+    },
     ExpressionAttributeValues: {
       ':subAreas': {
-        'SS': [subarea]
+        'L': [{
+          'M': {
+            'id': {'S': subarea.id},
+            'name': {'S': subarea.name}
+          }
+        }]
       }
     }
   };
@@ -212,7 +237,7 @@ async function putItem(record, overwrite = false) {
 }
 
 doMigration()
-.then((res) => {
-  console.log(`Import complete. ${res} records processed.`);
-})
-.catch((e) => console.log("Error:", e))
+  .then((res) => {
+    console.log(`Import complete. ${res} records processed.`);
+  })
+  .catch((e) => console.log("Error:", e))


### PR DESCRIPTION
###Jira Ticket
BRS-615
https://bcparksdigital.atlassian.net/jira/software/projects/BRS/issues/BRS-615

This ticket adds a unique ID number to each subarea. The numbers are sequential; the next sequential number can be used to identify new subareas as they need to be created. This UID is a better unique identifier to use both in partition/sort keys and in API calls, so the DynamoDB seeding script and lambdas have been updated accordingly. The updated data models are as follows:

```
Park:
pk: park
sk: <orcs>
example: park, 0001 = 'Strathcona Park'

SubArea:
pk: park::<orcs>
sk: <subAreaId>
example: subarea::0001, 0403 = 'Buttle Lake'

Config:
pk: config::<subAreaId>
sk: <activity>
example: config::0403, Day Use = 'Buttle Lake - Day Use (config)'

Record:
pk: <subAreaId>::<activity>
sk: <date>
example: 0403::Day Use, 202205 = saved record for 'Buttle Lake - Day Use - May 2022'
```

The databases will have to be reseeded using the `convertParksSheet.js` node script as the seeding table has been updated to include the new UIDs. A 'TEST PARK/SUBAREA' has also been added with `orcs = subAreaId = 'TEST'`.