### PR TITLE
BRS-654/655 adding formulae to backend

### DIFF
--- a/lambda/export/constants.js
+++ b/lambda/export/constants.js
@@ -200,6 +200,12 @@ const CSV_SYSADMIN_SCHEMA = [
     width: 63,
     value: (report) => report.totalAttendanceParties,
   },
+  {
+    column: "Frontcountry Cabins - Parties - Total Attendance",
+    type: Number,
+    width: 63,
+    value: (report) => report.calc_frontcountryCabins_parties_totalAttendance,
+  },
   // Frontcountry Cabins - Camping
   {
     column: "Frontcountry Cabins - Camping - Gross camping revenue",

--- a/lambda/export/invokable/index.js
+++ b/lambda/export/invokable/index.js
@@ -15,6 +15,7 @@ const {
   basicNetRevenue,
   frontcountryCampingPartyAttendance,
   frontcountryCampingSecondCarAttendance,
+  frontcountryCabinsPartiesAttendance,
   groupCampingStandardAttendance,
   dayUseVehicleAttendance,
   backcountryCabinsAttendance,
@@ -209,6 +210,11 @@ async function modifyReportForCSV(report) {
       ]).result;
       break;
     case "Frontcountry Cabins":
+      // Parties - TOTAL ATTENDANCE
+      report.calc_frontcountryCabins_parties_totalAttendance = frontcountryCabinsPartiesAttendance(
+        [report.totalAttendanceParties],
+        report.config.attendanceModifier
+      ).result;
       // NET REVENUE
       report.calc_frontcountryCabins_camping_netRevenue = basicNetRevenue([
         report.revenueGrossCamping,
@@ -237,6 +243,7 @@ async function modifyReportForCSV(report) {
       // People and vehicles - VEHICLE ATTENDANCE
       report.calc_dayUse_peopleAndVehicles_vehicleAttendance =
         dayUseVehicleAttendance(
+          [report.peopleAndVehiclesTrail],
           [report.peopleAndVehiclesVehicle],
           [report.peopleAndVehiclesBus],
           report.config.attendanceVehiclesModifier,

--- a/lambda/formulaUtils.js
+++ b/lambda/formulaUtils.js
@@ -99,6 +99,17 @@ exports.frontcountryCampingSecondCarAttendance = function (attendances) {
   };
 };
 
+exports.frontcountryCabinsPartiesAttendance = function (attendances, modifier) {
+  let formula = `Total attendance = Parties`;
+  if (modifier) {
+    formula += ` x ${modifier}`;
+  }
+  return {
+    result: formatTotalWithModifier(attendances, modifier),
+    formula: formula
+  };
+};
+
 exports.groupCampingStandardAttendance = function (attendances) {
   return {
     result: formatTotalWithModifier(attendances),
@@ -107,11 +118,13 @@ exports.groupCampingStandardAttendance = function (attendances) {
 };
 
 exports.dayUseVehicleAttendance = function (
+  trailCount,
   vehicles,
   buses,
   vehicleMod,
   busMod
 ) {
+  let trailCountTotal = totalWithModifier(trailCount);
   let vehicleTotal = totalWithModifier(vehicles, vehicleMod);
   let busTotal = totalWithModifier(buses, busMod);
   let vehicleFormula = "Vehicles";
@@ -123,8 +136,8 @@ exports.dayUseVehicleAttendance = function (
     busFormula = `(Bus count x ${busMod})`;
   }
   return {
-    result: formatTotalWithModifier([vehicleTotal, busTotal]),
-    formula: `Vehicle attendance = ${vehicleFormula} + ${busFormula}`,
+    result: formatTotalWithModifier([vehicleTotal, busTotal, trailCountTotal]),
+    formula: `Vehicle attendance = ${vehicleFormula} + ${busFormula} + Trail count`,
   };
 };
 


### PR DESCRIPTION
BRS-654/BRS-655

https://bcparksdigital.atlassian.net/browse/BRS-654
https://bcparksdigital.atlassian.net/browse/BRS-655

NOTE: This change was originally implemented and then reverted due to the exporter lambdas looping indefinitely when encountering an error. 

This change adds to and updates some formulae captured in the exporter. The new formulae are:

For Frontcountry Cabins:
Total Attendance = Parties x 3.2

For Day Use:
Total Attendance = (Vehicles x 3.5) + (Buses x 40) + Trail counter

Due to the exporter's reliance on S3 buckets to store reports, this change is difficult to test locally. The current AWS sandbox environment has these changes under the live API https://n10uxmdaq0.execute-api.ca-central-1.amazonaws.com/api.