### PR TITLE
BRS-701 fixes to migration script

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -28,6 +28,16 @@ const dynamodb = new AWS.DynamoDB(options);
 
 exports.dynamodb = new AWS.DynamoDB();
 
+// simple way to return a single Item by primary key.
+async function getOne(pk, sk) {
+  logger.debug(`getItem: { pk: ${pk}, sk: ${sk} }`);
+  const params = {
+    TableName: TABLE_NAME,
+    Key: AWS.DynamoDB.Converter.marshall({pk, sk})
+  };
+  let item = await dynamodb.getItem(params).promise();
+  return item?.Item || {};
+};
 // TODO: set paginated to TRUE by default. Query results will then be at most 1 page
 // (1MB) unless they are explicitly specified to retrieve more.
 // TODO: Ensure the returned object has the same structure whether results are paginated or not. 
@@ -115,4 +125,5 @@ module.exports = {
   dynamodb,
   runQuery,
   runScan,
+  getOne
 };

--- a/migrations/20220825185430-newEntries-1.js
+++ b/migrations/20220825185430-newEntries-1.js
@@ -35,7 +35,8 @@ async function deleteEntries() {
       sk: '0163',
     },
   ];
-  let completed = 0;
+  let configCompleted = 0;
+  let subAreaCompleted = 0;
   try {
     for (const obj of toDelete) {
       // collect all config items for the subArea:
@@ -56,13 +57,24 @@ async function deleteEntries() {
           }
         }
         await dynamodb.deleteItem(deleteObj).promise();
-        completed++;
+        configCompleted++;
       }
+      // delete the subArea
+      const deleteSubAreaObj = {
+        TableName: TABLE_NAME,
+        Key: {
+          pk: { S: obj.pk },
+          sk: { S: obj.sk },
+        }
+      }
+      await dynamodb.deleteItem(deleteSubAreaObj).promise();
+      subAreaCompleted++;
     }
-    console.log(`Successfully deleted ${completed} config objects.`);
-  } catch (err) {
-    console.log('There was an error deleting config objects:', err);
-  }
+    console.log(`Successfully deleted ${configCompleted} config objects.`);
+    console.log(`Successfully deleted ${subAreaCompleted} subArea objects.`);
+} catch (err) {
+  console.log('There was an error deleting config objects:', err);
+}
 }
 
 async function createEntries() {


### PR DESCRIPTION
The `addToCSV` script that was used to migrate the new data in this ticket was built from a script that expects an empty DB to start with. As such there were errors occurring in some areas where a check for existing data needed to be performed. This change updates the `addToCSV` script to check for existing data in these cases. 

DEV and TEST DBs, where this migration was originally run before, will have this migration rerun. In the known cases where rerunning the migration will not solve the errors created by the previous migration run, the data will be manually updated in DEV and TEST (removing duplicates).