### PR TITLE
BRS-799-2 dynamoUtil improvements

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -110,6 +110,30 @@ async function runScan(query, paginated = false) {
   }
 }
 
+// returns all parks in the database.
+async function getParks() {
+  const parksQuery = {
+    TableName: TABLE_NAME,
+    KeyConditionExpression: 'pk = :pk',
+    ExpressionAttributeValues: {
+      ':pk': { S: 'park' }
+    }
+  };
+  return await runQuery(parksQuery);
+}
+
+// returns all subareas within an ORCS.
+async function getSubAreas(orcs) {
+  const subAreaQuery = {
+    TableName: TABLE_NAME,
+    KeyConditionExpression: 'pk = :pk',
+    ExpressionAttributeValues: {
+      ':pk': { S: `park::${orcs}` },
+    }
+  };
+  return await runQuery(subAreaQuery);
+}
+
 module.exports = {
   ACTIVE_STATUS,
   RESERVED_STATUS,
@@ -125,5 +149,7 @@ module.exports = {
   dynamodb,
   runQuery,
   runScan,
-  getOne
+  getOne,
+  getParks,
+  getSubAreas
 };


### PR DESCRIPTION
Adding helper functions `getParks()` and `getSubAreas()` as these calls are used frequently. We do something similar in our DUP product already. 

A couple of the migrations run lately are dependent on these functions - but have been running smoothly since they were already in my repo, just uncommitted. 