### PR TITLE
BRS-502 Lock/Unlock records & fiscal years

### DIFF
--- a/__tests__/fiscalYearEnd.test.js
+++ b/__tests__/fiscalYearEnd.test.js
@@ -1,0 +1,94 @@
+const AWS = require('aws-sdk');
+const { DocumentClient } = require('aws-sdk/clients/dynamodb');
+const { REGION, ENDPOINT, TABLE_NAME } = require('./global/settings');
+const { FISCAL_YEAR_LOCKS } = require('./global/data.json');
+
+const fiscalYearEndGET = require('../lambda/fiscalYearEnd/GET/index');
+const fiscalYearEndPOST = require('../lambda/fiscalYearEnd/POST/index');
+
+const jwt = require('jsonwebtoken');
+const token = jwt.sign({ resource_access: { 'attendance-and-revenue': { roles: ['sysadmin'] } } }, 'defaultSecret');
+
+async function setupDb() {
+  new AWS.DynamoDB({
+    region: REGION,
+    endpoint: ENDPOINT
+  });
+  docClient = new DocumentClient({
+    region: REGION,
+    endpoint: ENDPOINT,
+    convertEmptyValues: true
+  });
+
+  for (const item of FISCAL_YEAR_LOCKS) {
+    await (genericPutDocument(item));
+  }
+}
+
+async function genericPutDocument(item) {
+  return await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: item
+    })
+    .promise();
+}
+
+describe('Fiscal Year End Test', () => {
+  beforeAll(async () => {
+    return await setupDb();
+  });
+
+  test('Handler - 200 GET fiscal year end', async () => {
+    const obj = await fiscalYearEndGET.handler(
+      {
+        headers: {
+          Authorization: "Bearer " + token
+        },
+        queryStringParameters: {
+          fiscalYearEnd: FISCAL_YEAR_LOCKS[0].sk
+        }
+      }, null);
+    expect(JSON.parse(obj.body)).toMatchObject(FISCAL_YEAR_LOCKS[0]);
+  });
+
+  test('Handler - 400 GET Bad Request', async () => {
+    const response = await fiscalYearEndGET.handler({
+      headers: {
+        Authorization: "Bearer " + token
+      },
+      queryStringParameters: {
+        badParam: "oops"
+      }
+    }, null);
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  test('HandleLock - 200 lock fiscal year', async () => {
+    const response = await fiscalYearEndPOST.lockFiscalYear({
+      headers: {
+        Authorization: "Bearer " + token
+      },
+      queryStringParameters: {
+        fiscalYearEnd: "2018"
+      }
+    }, null);
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('HandleLock - 200 unlock fiscal year', async () => {
+    const response = await fiscalYearEndPOST.unlockFiscalYear({
+      headers: {
+        Authorization: "Bearer " + token
+      },
+      queryStringParameters: {
+        fiscalYearEnd: "2018"
+      }
+    }, null);
+
+    expect(response.statusCode).toBe(200);
+  });
+
+});

--- a/__tests__/global/data.json
+++ b/__tests__/global/data.json
@@ -106,6 +106,27 @@
       "notes": "Some notes",
       "otherSkiiRevenue": 0,
       "picnicRentals": 5
+    },
+    {
+      "pk": "0087::Frontcountry Camping",
+      "sk": "201801",
+      "parkName": "Cultus Lake Park",
+      "attendanceVehicleModifier": 3.5,
+      "attendanceBusModifier": 40,
+      "subAreaName": "Maple Bay",
+      "orcs": "0041",
+      "notes": "This one should be locked by fiscal year"
+    },
+    {
+      "pk": "0087::Frontcountry Camping",
+      "sk": "201901",
+      "parkName": "Cultus Lake Park",
+      "attendanceVehicleModifier": 3.5,
+      "attendanceBusModifier": 40,
+      "subAreaName": "Maple Bay",
+      "orcs": "0041",
+      "notes": "This one should be locked directly",
+      "isLocked": false
     }
   ],
   "CONFIG_ENTRIES": [
@@ -130,6 +151,13 @@
       "subAreaId": "0087",
       "orcs": "0041",
       "activity": "Frontcountry Camping"
+    }
+  ],
+  "FISCAL_YEAR_LOCKS": [
+    {
+      "pk": "fiscalYearEnd",
+      "sk": "2018",
+      "isLocked": true
     }
   ]
 }

--- a/__tests__/subarea.test.js
+++ b/__tests__/subarea.test.js
@@ -166,7 +166,7 @@ describe('Subarea Test', () => {
     expect(response.statusCode).toBe(200);
   });
 
-  test('HandlePost - 403 POST to locked record', async () => {
+  test('HandlePost - 409 POST to locked record', async () => {
     const response = await subareaPOST.handlePost(
       {
         headers: {
@@ -179,7 +179,7 @@ describe('Subarea Test', () => {
           date: "201901" // should be locked as per previous test
         })
       }, null);
-    expect(response.statusCode).toBe(403);
+    expect(response.statusCode).toBe(409);
   });
 
   test('HandleUnlock - 200 POST unlock record', async () => {

--- a/__tests__/subarea.test.js
+++ b/__tests__/subarea.test.js
@@ -1,7 +1,7 @@
 const AWS = require('aws-sdk');
 const { DocumentClient } = require('aws-sdk/clients/dynamodb');
 const { REGION, ENDPOINT, TABLE_NAME } = require('./global/settings');
-const { PARKSLIST, SUBAREAS, CONFIG_ENTRIES, SUBAREA_ENTRIES } = require('./global/data.json');
+const { PARKSLIST, SUBAREAS, CONFIG_ENTRIES, SUBAREA_ENTRIES, FISCAL_YEAR_LOCKS } = require('./global/data.json');
 
 const subareaGET = require('../lambda/subarea/GET/index');
 const subareaPOST = require('../lambda/subarea/POST/index');
@@ -30,6 +30,9 @@ async function setupDb() {
     await (genericPutDocument(item));
   }
   for (const item of CONFIG_ENTRIES) {
+    await (genericPutDocument(item));
+  }
+  for (const item of FISCAL_YEAR_LOCKS) {
     await (genericPutDocument(item));
   }
 }
@@ -77,14 +80,11 @@ describe('Subarea Test', () => {
     expect(response.statusCode).toBe(400);
   });
 
-  test('Handler - 200 POST handle Activity', async () => {
-    const response = await subareaPOST.handler(
+  test('HandlePost - 200 POST handle Activity', async () => {
+    const response = await subareaPOST.handlePost(
       {
         headers: {
           Authorization: "Bearer " + token
-        },
-        queryStringParameters: {
-          type: "activity"
         },
         body: JSON.stringify({
           orcs: SUBAREA_ENTRIES[0].orcs,
@@ -96,28 +96,13 @@ describe('Subarea Test', () => {
     expect(response.statusCode).toBe(200);
   });
 
-  test('Handler - 200 POST handle Config', async () => {
-    const response = await subareaPOST.handler(
-      {
-        headers: {
-          Authorization: "Bearer " + token
-        },
-        queryStringParameters: {
-          type: "config"
-        },
-        body: JSON.stringify(CONFIG_ENTRIES[0])
-      }, null);
-    expect(response.statusCode).toBe(200);
-  });
+  // note: CONFIG POST disabled 2022-09-27
 
-  test('Handler - 400 POST handle Activity', async () => {
-    const response = await subareaPOST.handler(
+  test('HandlePost - 400 POST handle Activity', async () => {
+    const response = await subareaPOST.handlePost(
       {
         headers: {
           Authorization: "Bearer " + token
-        },
-        queryStringParameters: {
-          type: "activity"
         },
         body: JSON.stringify({
           orcs: SUBAREA_ENTRIES[0].orcs,
@@ -126,43 +111,21 @@ describe('Subarea Test', () => {
     expect(response.statusCode).toBe(400);
   });
 
-  test('Handler - 400 POST handle Config', async () => {
-    const response = await subareaPOST.handler(
+  test('HandlePost - 400 POST handle Activity', async () => {
+    const response = await subareaPOST.handlePost(
       {
         headers: {
           Authorization: "Bearer " + token
         },
-        queryStringParameters: {
-          type: "config"
-        },
-        body: JSON.stringify({
-          orcs: SUBAREA_ENTRIES[0].orcs,
-        })
       }, null);
     expect(response.statusCode).toBe(400);
   });
 
-  test('Handler - 400 POST handle Activity', async () => {
-    const response = await subareaPOST.handler(
+  test('HandlePost - 400 POST handle Activity date', async () => {
+    const response = await subareaPOST.handlePost(
       {
         headers: {
           Authorization: "Bearer " + token
-        },
-        queryStringParameters: {
-          type: "activity"
-        }
-      }, null);
-    expect(response.statusCode).toBe(400);
-  });
-
-  test('Handler - 400 POST handle Activity date', async () => {
-    const response = await subareaPOST.handler(
-      {
-        headers: {
-          Authorization: "Bearer " + token
-        },
-        queryStringParameters: {
-          type: "activity"
         },
         body: JSON.stringify({
           orcs: SUBAREA_ENTRIES[0].orcs,
@@ -174,8 +137,8 @@ describe('Subarea Test', () => {
     expect(response.statusCode).toBe(400);
   });
 
-  test('Handler - 400 POST Bad Request', async () => {
-    const response = await subareaPOST.handler({
+  test('HandlePost - 400 POST Bad Request', async () => {
+    const response = await subareaPOST.handlePost({
       headers: {
         Authorization: "Bearer " + token
       },
@@ -185,5 +148,69 @@ describe('Subarea Test', () => {
     }, null);
 
     expect(response.statusCode).toBe(400);
+  });
+
+  test('HandleLock - 200 POST lock record', async () => {
+    const response = await subareaPOST.handleLock(
+      {
+        headers: {
+          Authorization: "Bearer " + token
+        },
+        body: JSON.stringify({
+          orcs: SUBAREA_ENTRIES[3].orcs,
+          subAreaId: SUBAREA_ENTRIES[3].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[3].pk.split("::")[1],
+          date: "201901"
+        })
+      }, null);
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('HandlePost - 403 POST to locked record', async () => {
+    const response = await subareaPOST.handlePost(
+      {
+        headers: {
+          Authorization: "Bearer " + token
+        },
+        body: JSON.stringify({
+          orcs: SUBAREA_ENTRIES[3].orcs,
+          subAreaId: SUBAREA_ENTRIES[3].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[3].pk.split("::")[1],
+          date: "201901" // should be locked as per previous test
+        })
+      }, null);
+    expect(response.statusCode).toBe(403);
+  });
+
+  test('HandleUnlock - 200 POST unlock record', async () => {
+    const response = await subareaPOST.handleUnlock(
+      {
+        headers: {
+          Authorization: "Bearer " + token
+        },
+        body: JSON.stringify({
+          orcs: SUBAREA_ENTRIES[3].orcs,
+          subAreaId: SUBAREA_ENTRIES[3].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[3].pk.split("::")[1],
+          date: "201901"
+        })
+      }, null);
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('Handler - 403 POST to locked fiscal year', async () => {
+    const response = await subareaPOST.handlePost(
+      {
+        headers: {
+          Authorization: "Bearer " + token
+        },
+        body: JSON.stringify({
+          orcs: SUBAREA_ENTRIES[2].orcs,
+          subAreaId: SUBAREA_ENTRIES[2].pk.split("::")[0],
+          activity: SUBAREA_ENTRIES[2].pk.split("::")[1],
+          date: "201801" // Fiscal year is locked
+        })
+      }, null);
+    expect(response.statusCode).toBe(403);
   });
 });

--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -36,7 +36,10 @@ async function getOne(pk, sk) {
     Key: AWS.DynamoDB.Converter.marshall({pk, sk})
   };
   let item = await dynamodb.getItem(params).promise();
-  return item?.Item || {};
+  if (item?.Item) {
+    return AWS.DynamoDB.Converter.unmarshall(item.Item);
+  }
+  return {};
 };
 // TODO: set paginated to TRUE by default. Query results will then be at most 1 page
 // (1MB) unless they are explicitly specified to retrieve more.

--- a/lambda/fiscalYearEnd/GET/index.js
+++ b/lambda/fiscalYearEnd/GET/index.js
@@ -29,7 +29,6 @@ async function getDateConfig(year) {
   // check db for fiscalYearEnd object
   try {
     let fiscalYearEnd = await getOne('fiscalYearEnd', year);
-    // fiscalYearEnd = AWS.DynamoDB.Converter.unmarshall(fiscalYearEnd);
     logger.debug('fiscalYearEnd object:', fiscalYearEnd);
     return fiscalYearEnd;
   } catch (err) {

--- a/lambda/fiscalYearEnd/GET/index.js
+++ b/lambda/fiscalYearEnd/GET/index.js
@@ -1,0 +1,41 @@
+const { getOne } = require('../../dynamoUtil');
+const { sendResponse } = require('../../responseUtil');
+const { logger } = require('../../logger');
+
+exports.handler = async (event, context) => {
+  logger.debug('GET: dateConfig', event);
+  try {
+    const year = getDate(event);
+    const fiscalYearEnd = await getDateConfig(year);
+    logger.debug('fiscalYearEnd Object:', fiscalYearEnd);
+    return sendResponse(200, fiscalYearEnd);
+  } catch (err) {
+    logger.error(err);
+    return sendResponse(err.code ?? 1, { msg: err.msg ?? err }, context);
+  }
+}
+
+function getDate(event) {
+  if (!event?.queryStringParameters?.fiscalYearEnd) {
+    throw {
+      code: 400,
+      msg: "Error: Must provide a fiscal year. Format: yyyy"
+    };
+  }
+  return event.queryStringParameters.fiscalYearEnd;
+}
+
+async function getDateConfig(year) {
+  // check db for fiscalYearEnd object
+  try {
+    let fiscalYearEnd = await getOne('fiscalYearEnd', year);
+    // fiscalYearEnd = AWS.DynamoDB.Converter.unmarshall(fiscalYearEnd);
+    logger.debug('fiscalYearEnd object:', fiscalYearEnd);
+    return fiscalYearEnd;
+  } catch (err) {
+    throw {
+      code: 400,
+      msg: err
+    }
+  }
+}

--- a/lambda/fiscalYearEnd/POST/index.js
+++ b/lambda/fiscalYearEnd/POST/index.js
@@ -1,0 +1,85 @@
+const AWS = require('aws-sdk');
+const { TABLE_NAME, dynamodb } = require('../../dynamoUtil');
+const { sendResponse } = require('../../responseUtil');
+const { logger } = require('../../logger');
+const { decodeJWT, resolvePermissions } = require('../../permissionUtil');
+
+// lock the fiscal year from further edits
+exports.lockFiscalYear = async (event, context) => {
+  return await handleLockUnlock(true, event, context);
+}
+
+// unlock the fiscal year
+exports.unlockFiscalYear = async (event, context) => {
+  return await handleLockUnlock(false, event, context);
+}
+
+async function handleLockUnlock(isLocked, event, context) {
+  const type = isLocked ? 'lock' : 'unlock';
+  logger.debug(`POST: ${type} fiscal year`, event);
+  try {
+    await checkPermissions(event);
+    const params = verifyEventParams(event);
+    const res = await putFiscalYear(isLocked, params);
+    logger.debug('POST result:', res);
+    return sendResponse(200, res);
+  } catch (error) {
+    logger.error(error);
+    return sendResponse(error.code ?? 1, { error }, context);
+  }
+}
+
+async function checkPermissions(event) {
+  const token = await decodeJWT(event);
+  const permissionObject = resolvePermissions(token);
+  if (!permissionObject.isAdmin) {
+    throw {
+      code: 403,
+      msg: 'Unauthorized'
+    }
+  }
+  return permissionObject;
+}
+
+function verifyEventParams(event) {
+  const params = event?.queryStringParameters || null;
+  if (!params || !params.fiscalYearEnd) {
+    throw {
+      code: 400,
+      msg: `Missing parameters. Must provide 'fiscalYearEnd'.`
+    };
+  }
+  const regex = new RegExp('^[0-9]{4}$');
+  const validYear = regex.test(params.fiscalYearEnd);
+  if (!validYear) {
+    throw {
+      code: 400,
+      msg: `Invalid fiscal year. Format: 'yyyy'`
+    };
+  }
+  return params;
+}
+
+async function putFiscalYear(isLocked, params) {
+  try {
+    const newObject = {
+      pk: 'fiscalYearEnd',
+      sk: params.fiscalYearEnd,
+      isLocked: isLocked
+    }
+    const putObj = {
+      TableName: TABLE_NAME,
+      Item: AWS.DynamoDB.Converter.marshall(newObject),
+    };
+    await dynamodb.putItem(putObj).promise();
+    logger.debug('Updated fiscalYearEnd Object:', newObject);
+    return newObject;
+  } catch (err) {
+    logger.error(err);
+    throw {
+      code: 400,
+      msg: 'Error putting object in database.'
+    }
+  }
+}
+

--- a/lambda/subarea/POST/index.js
+++ b/lambda/subarea/POST/index.js
@@ -1,10 +1,27 @@
 const AWS = require("aws-sdk");
-const { dynamodb, runQuery, TABLE_NAME } = require("../../dynamoUtil");
+const { dynamodb, runQuery, TABLE_NAME, getOne } = require("../../dynamoUtil");
 const { sendResponse } = require("../../responseUtil");
 const { decodeJWT, roleFilter, resolvePermissions } = require('../../permissionUtil');
 const { logger } = require('../../logger');
 
-exports.handler = async (event, context) => {
+const FISCAL_YEAR_FINAL_MONTH = 3;
+
+exports.handlePost = async (event, context) => {
+  logger.debug('Subarea POST:', event);
+  return await main(event, context);
+};
+
+exports.handleLock = async (event, context) => {
+  logger.debug('Record Lock POST:', event);
+  return await main(event, context, true);
+};
+
+exports.handleUnlock = async (event, context) => {
+  logger.debug('Record Unlock POST:', event);
+  return await main(event, context, false);
+};
+
+async function main(event, context, lock = null) {
   try {
     const token = await decodeJWT(event);
     const permissionObject = resolvePermissions(token);
@@ -20,26 +37,92 @@ exports.handler = async (event, context) => {
       return sendResponse(403, { msg: 'Unauthorized.' }, context);
     }
 
-    if (event?.queryStringParameters?.type === "config") {
-      return await handleConfig(body, context);
-    } else if (event?.queryStringParameters?.type === "activity") {
-      // Handle standard monthly entry for this orc::subAreaName::activity
-      return await handleActivity(body);
-    } else {
-      throw "Invalid request";
+    // check if fiscal year is locked
+    if (await checkFiscalYearLock(body)) {
+      return sendResponse(403, { msg: `This fiscal year has been locked against editing by the system administrator.` }, context)
     }
+
+    // Disabling the ability to change config for now. 
+    // Request used to necessitate 'type = activity/config' as a queryParam (was future proofing).
+    // Queryparams no longer required. All info included in request body. 
+    // Refer to code prior to 2022-09-27 for handleConfig.
+
+    await verifyBody(body);
+
+    // check if record is locked
+    const unlocking = lock === false ? true : false;
+    const existingRecord = await getOne(`${body.subAreaId}::${body.activity}`, body.date);
+    if (existingRecord?.isLocked && !unlocking) {
+      return sendResponse(403, { msg: 'Record is locked.' });
+    }
+
+    // handle locking/unlocking existing records
+    if (lock !== null) {
+      if (existingRecord?.pk) {
+        return await handleLockUnlock(existingRecord, lock, context);
+      } else if (lock === false) {
+        // if record doesnt exist, we can't unlock it
+        return sendResponse(404, { msg: 'Record not found.' });
+      }
+      // if we are locking a record that doesn't exist, we need to create it.
+      // fall through and create new record for locking.
+    }
+    return await handleActivity(body, context);
   } catch (err) {
     logger.error(err);
     return sendResponse(400, { msg: "Invalid request" }, context);
   }
 };
 
+async function checkFiscalYearLock(body) {
+  // extract fiscal year from date
+  let recordYear = Number(body.date.slice(0, 4));
+  let recordMonth = Number(body.date.slice(4, 6));
+  if (recordMonth > FISCAL_YEAR_FINAL_MONTH) {
+    recordYear++;
+  }
+  const fiscalYearEndObj = await getOne('fiscalYearEnd', String(recordYear));
+  if (fiscalYearEndObj?.isLocked) {
+    return true;
+  }
+  return false;
+}
+
+async function verifyBody(body) {
+  if (!body.subAreaId || !body.activity || !body.date) {
+    return sendResponse(400, { msg: "Invalid request." });
+  };
+
+  // delete isLocked - need correct path to lock/unlock records
+  delete body.isLocked;
+}
+
+async function handleLockUnlock(record, lock, context) {
+  const updateObj = {
+    TableName: TABLE_NAME,
+    Key: {
+      pk: { S: record.pk },
+      sk: { S: record.sk }
+    },
+    UpdateExpression: 'set isLocked = :isLocked',
+    ExpressionAttributeValues: {
+      ':isLocked': { BOOL: lock }
+    },
+    ReturnValues: 'ALL_NEW'
+  };
+  try {
+    const res = await dynamodb.updateItem(updateObj).promise();
+    logger.debug(`Updated record pk: ${record.pk}, sk: ${record.sk} `);
+    const s = lock ? 'locked' : 'unlocked';
+    return sendResponse(200, {msg: `Record successfully ${s}`, data: AWS.DynamoDB.Converter.unmarshall(res.Attributes)});
+  } catch (err) {
+    return sendResponse(400, {msg: 'Record lock/unlock failed: ', error: err});
+  }
+}
+
 async function handleActivity(body, context) {
   // Set pk/sk
   try {
-    if (!body.subAreaId || !body.activity || !body.date) {
-      throw "Invalid request.";
-    }
 
     const pk = `${body.subAreaId}::${body.activity}`;
 
@@ -47,13 +130,19 @@ async function handleActivity(body, context) {
     const configObj = {
       TableName: TABLE_NAME,
       ExpressionAttributeValues: {
-        ":pk": { S: `config::${body.subAreaId}`},
+        ":pk": { S: `config::${body.subAreaId}` },
         ":sk": { S: body.activity },
       },
       KeyConditionExpression: "pk =:pk AND sk =:sk",
     };
     const configData = (await runQuery(configObj))[0];
+    if (!configData?.orcs || !configData?.parkName) {
+      throw 'Malformed config object';
+    };
     body["config"] = configData;
+    body["orcs"] = body["orcs"] ? body["orcs"] : configData.orcs;
+    body["parkName"] = body["parkName"] ? body["parkName"] : configData.parkName;
+    body["subAreaName"] = body["subAreaName"] ? body["subAreaName"] : configData.subAreaName;
 
     body["pk"] = pk;
 
@@ -64,31 +153,7 @@ async function handleActivity(body, context) {
     body["sk"] = body.date;
     body["lastUpdated"] = new Date().toISOString();
 
-    const newObject = AWS.DynamoDB.Converter.marshall(body);
-
-    let putObject = {
-      TableName: TABLE_NAME,
-      Item: newObject,
-    };
-
-    await dynamodb.putItem(putObject).promise();
-    return sendResponse(200, {}, context);
-  } catch (err) {
-    logger.error(err);
-    return sendResponse(400, err, context);
-  }
-}
-
-async function handleConfig(body, context) {
-  try {
-    // Set pk/sk
-
-    if (!body.subAreaId || !body.activity) {
-      throw "Invalid request.";
-    }
-
-    body["pk"] = `config::${body.subAreaId}`;
-    body["sk"] = body.activity;
+    body["isLocked"] = false;
 
     const newObject = AWS.DynamoDB.Converter.marshall(body);
 

--- a/postman/BCParks Attendance and Revenue.postman_collection.json
+++ b/postman/BCParks Attendance and Revenue.postman_collection.json
@@ -91,6 +91,91 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Create Record",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"date\": \"202009\",\r\n    \"subAreaId\": \"TEST\",\r\n    \"activity\": \"Backcountry Camping\",\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}subarea",
+							"host": [
+								"{{base_url}}subarea"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "activity",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Create record. Must provide the following body as a minimum:\n\nStartFragment\n\n```\n{\n    \"date\": \"202209\", // date yyyyMM\n    \"subAreaId\": \"TEST\",\n    \"activity\": \"Backcountry Camping\"\n}\n\n```"
+					},
+					"response": []
+				},
+				{
+					"name": "Lock Record",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"date\": \"202209\",\r\n    \"subAreaId\": \"TEST\",\r\n    \"activity\": \"Backcountry Camping\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}subarea/lock",
+							"host": [
+								"{{base_url}}subarea"
+							],
+							"path": [
+								"lock"
+							]
+						},
+						"description": "Locks a record given the following info in the request body:\n\n```\n{\n    \"date\": \"202209\", // date \"yyyyMM\"\n    \"subAreaId\": \"TEST\", // subAreaId\n    \"activity\": \"Backcountry Camping\" //activity\n}\n\n```\n\nIf the record doesn't exist, a blank one will be created using the config object for that record, and locked."
+					},
+					"response": []
+				},
+				{
+					"name": "Unlock Record",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"date\": \"202209\",\r\n    \"subAreaId\": \"TEST\",\r\n    \"activity\": \"Backcountry Camping\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}subarea/unlock",
+							"host": [
+								"{{base_url}}subarea"
+							],
+							"path": [
+								"unlock"
+							]
+						},
+						"description": "Unlocks a record. The following is required in the request body:\n\n```\n{\n    \"date\": \"202209\", // date \"yyyyMM\"\n    \"subAreaId\": \"TEST\", // subareaID\n    \"activity\": \"Backcountry Camping\" //activity\n}\n\n```"
+					},
+					"response": []
 				}
 			]
 		},
@@ -114,6 +199,99 @@
 								}
 							]
 						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Date Configuration",
+			"item": [
+				{
+					"name": "Check Fiscal Year End Lock",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}fiscalYearEnd?fiscalYearEnd=2023",
+							"host": [
+								"{{base_url}}fiscalYearEnd"
+							],
+							"query": [
+								{
+									"key": "fiscalYearEnd",
+									"value": "2023"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Lock Fiscal Year End",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}fiscalYearEnd/lock?fiscalYearEnd=2021",
+							"host": [
+								"{{base_url}}fiscalYearEnd"
+							],
+							"path": [
+								"lock"
+							],
+							"query": [
+								{
+									"key": "fiscalYearEnd",
+									"value": "2021",
+									"description": "Calendar year the fiscal year ends in, eg: Fiscal is 2022-04 to 2023-03, fiscalYearEnd is 2023"
+								}
+							]
+						},
+						"description": "Locks fiscal year. The `fiscalYearEnd` param is the year the fiscal year closes (typically in March).\n\nex: `fiscalYearEnd=2023` is the fiscal year between 2022-04 and 2023-03."
+					},
+					"response": []
+				},
+				{
+					"name": "Unlock Fiscal Year End",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}fiscalYearEnd/unlock?fiscalYearEnd=2023",
+							"host": [
+								"{{base_url}}fiscalYearEnd"
+							],
+							"path": [
+								"unlock"
+							],
+							"query": [
+								{
+									"key": "fiscalYearEnd",
+									"value": "2023",
+									"description": "Calendar year the fiscal year ends in, eg: Fiscal is 2022-04 to 2023-03, fiscalYearEnd is 2023"
+								}
+							]
+						},
+						"description": "Unlocks fiscal year. The `fiscalYearEnd` param is the year the fiscal year closes (typically in March).\n\nex: `fiscalYearEnd=2023` is the fiscal year between 2022-04 and 2023-03."
 					},
 					"response": []
 				}

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,11 +59,27 @@ functions:
           cors: true
 
   subareaPost:
-    handler: lambda/subarea/POST/index.handler
+    handler: lambda/subarea/POST/index.handlePost
     events:
       - http:
           method: POST
           path: /subarea
+          cors: true
+
+  subareaRecordLock:
+    handler: lambda/subarea/POST/index.handleLock
+    events:
+      - http:
+          method: POST
+          path: /subarea/lock
+          cors: true
+
+  subareaRecordUnlock:
+    handler: lambda/subarea/POST/index.handleUnlock
+    events:
+      - http:
+          method: POST
+          path: /subarea/unlock
           cors: true
 
   ###########
@@ -77,6 +93,33 @@ functions:
       - http:
           method: GET
           path: /export
+          cors: true
+
+  ###########
+  # Fiscal Year End
+  ###########
+  fiscalYearEndGet:
+    handler: lambda/fiscalYearEnd/GET/index.handler
+    events:
+      - http:
+          method: GET
+          path: /fiscalYearEnd
+          cors: true
+
+  fiscalYearEndLock:
+    handler: lambda/fiscalYearEnd/POST/index.lockFiscalYear
+    events:
+      - http:
+          method: POST
+          path: /fiscalYearEnd/lock
+          cors: true
+
+  fiscalYearEndUnlock:
+    handler: lambda/fiscalYearEnd/POST/index.unlockFiscalYear
+    events:
+      - http:
+          method: POST
+          path: /fiscalYearEnd/unlock
           cors: true
 
 resources:

--- a/terraform/src/fiscalYearEnd.tf
+++ b/terraform/src/fiscalYearEnd.tf
@@ -1,0 +1,197 @@
+#getFiscalYearEnd
+resource "aws_lambda_function" "fiscalYearEndGetLambda" {
+  function_name = "fiscalYearEnd-get-${random_string.postfix.result}"
+
+  filename         = "artifacts/fiscalYearEndGet.zip"
+  source_code_hash = filebase64sha256("artifacts/fiscalYearEndGet.zip")
+
+  handler = "lambda/fiscalYearEnd/GET/index.handler"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.databaseReadRole.arn
+
+  environment {
+    variables = {
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
+      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "fiscalYearEndGetLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.fiscalYearEndGetLambda.function_name
+  function_version = aws_lambda_function.fiscalYearEndGetLambda.version
+}
+
+resource "aws_lambda_permission" "fiscalYearEndGetPermission" {
+  statement_id  = "fiscalYearEndGetPermissionInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.fiscalYearEndGetLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/fiscalYearEnd"
+}
+
+# fiscalYearEndLock
+resource "aws_lambda_function" "fiscalYearEndLockLambda" {
+  function_name = "fiscalYearEnd-lock-${random_string.postfix.result}"
+
+  filename         = "artifacts/fiscalYearEndLock.zip"
+  source_code_hash = filebase64sha256("artifacts/fiscalYearEndLock.zip")
+
+  handler = "lambda/fiscalYearEnd/POST/index.lockFiscalYear"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.databaseReadRole.arn
+
+  environment {
+    variables = {
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
+      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "fiscalYearEndLockLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.fiscalYearEndLockLambda.function_name
+  function_version = aws_lambda_function.fiscalYearEndLockLambda.version
+}
+
+resource "aws_lambda_permission" "fiscalYearEndLockPermission" {
+  statement_id  = "fiscalYearEndLockPermissionInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.fiscalYearEndLockLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/POST/fiscalYearEnd/lock"
+}
+
+# fiscalYearEndUnlock
+resource "aws_lambda_function" "fiscalYearEndUnlockLambda" {
+  function_name = "fiscalYearEnd-unlock-${random_string.postfix.result}"
+
+  filename         = "artifacts/fiscalYearEndUnlock.zip"
+  source_code_hash = filebase64sha256("artifacts/fiscalYearEndUnlock.zip")
+
+  handler = "lambda/fiscalYearEnd/POST/index.unlockFiscalYear"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.databaseReadRole.arn
+
+  environment {
+    variables = {
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
+      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "fiscalYearEndUnlockLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.fiscalYearEndUnlockLambda.function_name
+  function_version = aws_lambda_function.fiscalYearEndUnlockLambda.version
+}
+
+resource "aws_lambda_permission" "fiscalYearEndUnlockPermission" {
+  statement_id  = "fiscalYearEndUnlockPermissionInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.fiscalYearEndUnlockLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/POST/fiscalYearEnd/unlock"
+}
+
+# Resources - fiscalYearEnd
+module "fiscalYearEndResource" {
+  source               = "./modules/cors-enabled-api-resource"
+  resource_rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
+  resource_path_part   = "fiscalYearEnd"
+}
+
+// Defines the HTTP GET /fiscalYearEnd API
+resource "aws_api_gateway_method" "fiscalYearEndGet" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = module.fiscalYearEndResource.resource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "fiscalYearEndGetIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = module.fiscalYearEndResource.resource.id
+  http_method = aws_api_gateway_method.fiscalYearEndGet.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.fiscalYearEndGetLambda.invoke_arn
+}
+
+# Resources - fiscalYearEndLock
+module "fiscalYearEndLockResource" {
+  source               = "./modules/cors-enabled-api-resource"
+  resource_rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_parent_id   = module.fiscalYearEndResource.resource.id
+  resource_path_part   = "lock"
+}
+
+// Defines the HTTP POST /fiscalYearEnd Lock API
+resource "aws_api_gateway_method" "fiscalYearEndLockMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = module.fiscalYearEndLockResource.resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "fiscalYearEndLockIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = module.fiscalYearEndLockResource.resource.id
+  http_method = aws_api_gateway_method.fiscalYearEndLockMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.fiscalYearEndLockLambda.invoke_arn
+}
+
+# Resources - fiscal year end unlock
+module "fiscalYearEndUnlockResource" {
+  source               = "./modules/cors-enabled-api-resource"
+  resource_rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_parent_id   = module.fiscalYearEndResource.resource.id
+  resource_path_part   = "unlock"
+}
+
+// Defines the HTTP POST /fiscalYearEnd unlock API
+resource "aws_api_gateway_method" "fiscalYearEndUnlockMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = module.fiscalYearEndUnlockResource.resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "fiscalYearEndUnlockIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = module.fiscalYearEndUnlockResource.resource.id
+  http_method = aws_api_gateway_method.fiscalYearEndUnlockMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.fiscalYearEndUnlockLambda.invoke_arn
+}

--- a/terraform/src/main.tf
+++ b/terraform/src/main.tf
@@ -29,6 +29,9 @@ resource "aws_api_gateway_deployment" "apideploy" {
     aws_api_gateway_integration.subareaGetIntegration,
     aws_api_gateway_integration.subareaPostIntegration,
     aws_api_gateway_integration.exportGetIntegration,
+    aws_api_gateway_integration.fiscalYearEndGetIntegration,
+    aws_api_gateway_integration.fiscalYearEndLockIntegration,
+    aws_api_gateway_integration.fiscalYearEndUnlockIntegration
   ]
 
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id

--- a/terraform/src/modules/cors-enabled-api-resource/main.tf
+++ b/terraform/src/modules/cors-enabled-api-resource/main.tf
@@ -1,0 +1,63 @@
+resource "aws_api_gateway_resource" "this_api_resource" {
+  rest_api_id = var.resource_rest_api_id
+  parent_id   = var.resource_parent_id
+  path_part   = var.resource_path_part
+}
+
+resource "aws_api_gateway_method" "this_options_method" {
+  rest_api_id = var.resource_rest_api_id
+  resource_id = aws_api_gateway_resource.this_api_resource.id
+
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "this_options_method_response" {
+  rest_api_id = var.resource_rest_api_id
+  resource_id = aws_api_gateway_resource.this_api_resource.id
+  http_method = aws_api_gateway_method.this_options_method.http_method
+
+  status_code = "200"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+
+  depends_on = [aws_api_gateway_method.this_options_method]
+}
+
+resource "aws_api_gateway_integration" "this_options_integration" {
+  rest_api_id = var.resource_rest_api_id
+  resource_id = aws_api_gateway_resource.this_api_resource.id
+  http_method = aws_api_gateway_method.this_options_method.http_method
+
+  type = "MOCK"
+
+  request_templates = {
+    "application/json" : jsonencode({ statusCode = 200 })
+  }
+
+  depends_on = [aws_api_gateway_method.this_options_method]
+}
+
+resource "aws_api_gateway_integration_response" "config_options_integration_response" {
+  rest_api_id = var.resource_rest_api_id
+  resource_id = aws_api_gateway_resource.this_api_resource.id
+  http_method = aws_api_gateway_method.this_options_method.http_method
+
+  status_code = aws_api_gateway_method_response.this_options_method_response.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = var.allowed_headers,
+    "method.response.header.Access-Control-Allow-Methods" = var.allowed_methods,
+    "method.response.header.Access-Control-Allow-Origin"  = var.allowed_origin
+  }
+
+  depends_on = [aws_api_gateway_method_response.this_options_method_response]
+}

--- a/terraform/src/modules/cors-enabled-api-resource/outputs.tf
+++ b/terraform/src/modules/cors-enabled-api-resource/outputs.tf
@@ -1,0 +1,7 @@
+output "resource" {
+  value = aws_api_gateway_resource.this_api_resource
+}
+
+output "options_integration" {
+  value = aws_api_gateway_integration.this_options_integration
+}

--- a/terraform/src/modules/cors-enabled-api-resource/variables.tf
+++ b/terraform/src/modules/cors-enabled-api-resource/variables.tf
@@ -1,0 +1,26 @@
+variable "resource_rest_api_id" {
+  description = "Id of the API this resource belongs to"
+}
+
+variable "resource_parent_id" {
+  description = "Id of the resource this resource belongs to"
+}
+
+variable "resource_path_part" {
+  description = "Url path of this resource"
+}
+
+variable "allowed_headers" {
+  description = "Allowed CORS headers"
+  default     = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+}
+
+variable "allowed_methods" {
+  description = "Allowed CORS methods"
+  default     = "'GET,OPTIONS,POST,PUT,DELETE'"
+}
+
+variable "allowed_origin" {
+  description = "Allowed CORS origins"
+  default     = "'*'"
+}

--- a/terraform/src/subarea.tf
+++ b/terraform/src/subarea.tf
@@ -1,3 +1,4 @@
+#getSubArea
 resource "aws_lambda_function" "subareaGetLambda" {
   function_name = "subarea-get-${random_string.postfix.result}"
 
@@ -15,32 +16,8 @@ resource "aws_lambda_function" "subareaGetLambda" {
 
   environment {
     variables = {
-      SSO_ISSUER                   = data.aws_ssm_parameter.sso_issuer.value,
-      SSO_JWKSURI                  = data.aws_ssm_parameter.sso_jwksuri.value,
-      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
-    }
-  }
-}
-
-resource "aws_lambda_function" "subareaPostLambda" {
-  function_name = "subarea-post-${random_string.postfix.result}"
-
-  filename         = "artifacts/subareaPost.zip"
-  source_code_hash = filebase64sha256("artifacts/subareaPost.zip")
-
-  handler = "lambda/subarea/POST/index.handler"
-  runtime = "nodejs14.x"
-  timeout = 30
-  publish = "true"
-
-  memory_size = 128
-
-  role = aws_iam_role.databaseReadRole.arn
-
-  environment {
-    variables = {
-      SSO_ISSUER                   = data.aws_ssm_parameter.sso_issuer.value,
-      SSO_JWKSURI                  = data.aws_ssm_parameter.sso_jwksuri.value,
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
     }
   }
@@ -52,62 +29,43 @@ resource "aws_lambda_alias" "subareaGetLambdaLatest" {
   function_version = aws_lambda_function.subareaGetLambda.version
 }
 
-resource "aws_lambda_alias" "subareaPostLambdaLatest" {
-  name             = "latest"
-  function_name    = aws_lambda_function.subareaPostLambda.function_name
-  function_version = aws_lambda_function.subareaPostLambda.version
-}
-
-resource "aws_api_gateway_resource" "subareaResource" {
-  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
-  parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
-  path_part   = "subarea"
-}
-
-// Defines the HTTP GET /subarea API
-resource "aws_api_gateway_method" "subareaGet" {
-  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
-  resource_id   = aws_api_gateway_resource.subareaResource.id
-  http_method   = "GET"
-  authorization = "NONE"
-}
-
-// Integrates the APIG to Lambda via POST method
-resource "aws_api_gateway_integration" "subareaGetIntegration" {
-  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
-  resource_id = aws_api_gateway_resource.subareaResource.id
-  http_method = aws_api_gateway_method.subareaGet.http_method
-
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.subareaGetLambda.invoke_arn
-}
-
-// Defines the HTTP POST /subarea API
-resource "aws_api_gateway_method" "subareaPost" {
-  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
-  resource_id   = aws_api_gateway_resource.subareaResource.id
-  http_method   = "POST"
-  authorization = "NONE"
-}
-
-// Integrates the APIG to Lambda via POST method
-resource "aws_api_gateway_integration" "subareaPostIntegration" {
-  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
-  resource_id = aws_api_gateway_resource.subareaResource.id
-  http_method = aws_api_gateway_method.subareaPost.http_method
-
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.subareaPostLambda.invoke_arn
-}
-
 resource "aws_lambda_permission" "subareaGetPermission" {
   statement_id  = "subareaGetPermissionInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.subareaGetLambda.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/subarea"
+}
+
+#postSubArea
+resource "aws_lambda_function" "subareaPostLambda" {
+  function_name = "subarea-post-${random_string.postfix.result}"
+
+  filename         = "artifacts/subareaPost.zip"
+  source_code_hash = filebase64sha256("artifacts/subareaPost.zip")
+
+  handler = "lambda/subarea/POST/index.handlePost"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.databaseReadRole.arn
+
+  environment {
+    variables = {
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
+      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "subareaPostLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.subareaPostLambda.function_name
+  function_version = aws_lambda_function.subareaPostLambda.version
 }
 
 resource "aws_lambda_permission" "subareaPostPermission" {
@@ -118,51 +76,180 @@ resource "aws_lambda_permission" "subareaPostPermission" {
   source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/POST/subarea"
 }
 
-//CORS
-resource "aws_api_gateway_method" "subarea_options_method" {
+#lockSubAreaRecord
+resource "aws_lambda_function" "subareaRecordLockLambda" {
+  function_name = "subarea-record-lock-${random_string.postfix.result}"
+
+  filename         = "artifacts/subareaRecordLock.zip"
+  source_code_hash = filebase64sha256("artifacts/subareaRecordLock.zip")
+
+  handler = "lambda/subarea/POST/index.handleLock"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.databaseReadRole.arn
+
+  environment {
+    variables = {
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
+      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "subareaRecordLockLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.subareaRecordLockLambda.function_name
+  function_version = aws_lambda_function.subareaRecordLockLambda.version
+}
+
+resource "aws_lambda_permission" "subareaRecordLockPermission" {
+  statement_id  = "subareaRecordLockPermissionInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.subareaRecordLockLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/POST/subarea/lock"
+}
+
+#unlockSubAreaRecord
+resource "aws_lambda_function" "subareaRecordUnlockLambda" {
+  function_name = "subarea-record-unlock-${random_string.postfix.result}"
+
+  filename         = "artifacts/subareaRecordUnlock.zip"
+  source_code_hash = filebase64sha256("artifacts/subareaRecordUnlock.zip")
+
+  handler = "lambda/subarea/POST/index.handleUnlock"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.databaseReadRole.arn
+
+  environment {
+    variables = {
+      SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
+      TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "subareaRecordUnlockLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.subareaRecordUnlockLambda.function_name
+  function_version = aws_lambda_function.subareaRecordUnlockLambda.version
+}
+
+resource "aws_lambda_permission" "subareaRecordUnlockPermission" {
+  statement_id  = "subareaRecordUnlockPermissionInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.subareaRecordUnlockLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/POST/subarea/unlock"
+}
+
+# Resources - subareas
+module "subareaResource" {
+  source               = "./modules/cors-enabled-api-resource"
+  resource_rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
+  resource_path_part   = "subarea"
+}
+
+// Defines the HTTP GET /subarea API
+resource "aws_api_gateway_method" "subareaGet" {
   rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
-  resource_id   = aws_api_gateway_resource.subareaResource.id
-  http_method   = "OPTIONS"
+  resource_id   = module.subareaResource.resource.id
+  http_method   = "GET"
   authorization = "NONE"
 }
 
-resource "aws_api_gateway_method_response" "subarea_options_200" {
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "subareaGetIntegration" {
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id
-  resource_id = aws_api_gateway_resource.subareaResource.id
-  http_method = aws_api_gateway_method.subarea_options_method.http_method
-  status_code = "200"
-  response_models = {
-    "application/json" = "Empty"
-  }
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = true,
-    "method.response.header.Access-Control-Allow-Methods" = true,
-    "method.response.header.Access-Control-Allow-Origin"  = true
-  }
-  depends_on = [aws_api_gateway_method.subarea_options_method]
+  resource_id = module.subareaResource.resource.id
+  http_method = aws_api_gateway_method.subareaGet.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.subareaGetLambda.invoke_arn
 }
 
-resource "aws_api_gateway_integration" "subarea_options_integration" {
-  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
-  resource_id = aws_api_gateway_resource.subareaResource.id
-  http_method = aws_api_gateway_method.subarea_options_method.http_method
-  type        = "MOCK"
-  request_templates = {
-    "application/json" : "{\"statusCode\": 200}"
-  }
-  depends_on = [aws_api_gateway_method.subarea_options_method]
+// Defines the HTTP POST /subarea API
+resource "aws_api_gateway_method" "subareaPost" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = module.subareaResource.resource.id
+  http_method   = "POST"
+  authorization = "NONE"
 }
 
-resource "aws_api_gateway_integration_response" "subarea_options_integration_response" {
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "subareaPostIntegration" {
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id
-  resource_id = aws_api_gateway_resource.subareaResource.id
-  http_method = aws_api_gateway_method.subarea_options_method.http_method
+  resource_id = module.subareaResource.resource.id
+  http_method = aws_api_gateway_method.subareaPost.http_method
 
-  status_code = aws_api_gateway_method_response.subarea_options_200.status_code
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
-    "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS'",
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
-  }
-  depends_on = [aws_api_gateway_method_response.subarea_options_200]
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.subareaPostLambda.invoke_arn
+}
+
+# Resources - lock subareas
+module "subareaRecordLockResource" {
+  source               = "./modules/cors-enabled-api-resource"
+  resource_rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_parent_id   = module.subareaResource.resource.id
+  resource_path_part   = "lock"
+}
+
+// Defines the HTTP POST /subarea/lock API
+resource "aws_api_gateway_method" "subareaRecordLockMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = module.subareaRecordLockResource.resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "subareaRecordLockIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = module.subareaRecordLockResource.resource.id
+  http_method = aws_api_gateway_method.subareaRecordLockMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.subareaRecordLockLambda.invoke_arn
+}
+
+# Resources - unlock subareas
+module "subareaRecordUnlockResource" {
+  source               = "./modules/cors-enabled-api-resource"
+  resource_rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_parent_id   = module.subareaResource.resource.id
+  resource_path_part   = "unlock"
+}
+
+// Defines the HTTP POST /subarea/unlock API
+resource "aws_api_gateway_method" "subareaRecordUnlockMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = module.subareaRecordUnlockResource.resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "subareaRecordUnlockIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = module.subareaRecordUnlockResource.resource.id
+  http_method = aws_api_gateway_method.subareaRecordUnlockMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.subareaRecordUnlockLambda.invoke_arn
 }


### PR DESCRIPTION
This change includes the backend updates to enable locking/unlocking records.

There are 2 levels of locking: 1 on the record level against the record itself, and one at the fiscal year level, where all records within the fiscal year are locked against editing. If a record meets either one of these locking levels, it cannot be edited. 

New object `fiscalYearEnd` has been introduced with the following structure: 
```
pk: fiscalYearEnd
sk: 2023
isLocked: false
```
`sk` is the calendar year in which the fiscal year ends (2023 = 2022-04 to 2023-03). If `isLocked` is set to true, the fiscal year is locked against editing. 

New endpoints:
`GET ../fiscalYearEnd?fiscalYearEnd=2023` - get fiscalYearEnd object (to check locked status)
`POST ../fiscalYearEnd/lock?fiscalYearEnd=2023` - lock fiscalYearEnd object
`POST ../fiscalYearEnd/unlock?fiscalYearEnd=2023` - unlock fiscalYearEnd object

There are also new endpoints for `subarea`, which is the endpoint for creating/getting records.

`POST ../subarea/lock`
`POST ../subarea/unlock`

Both of the above requests must be accompanied by a body containing the following at a minimum:
```
subAreaID: 1234,
activity: Frontcountry Camping,
date: 202209
```
to uniquely identify the record to lock/unlock.

When a record is locked for the first time, the `isLocked: true` attribute is appended to the object. The absence of this attribute or setting `isLocked: false` indicates an unlocked record. 

When attempting to lock a record that does not yet exist, the API will create a blank record from the corresponding `config` object. 




