### PR TITLE
BRS-502-3 exporter trying to pull fiscalYearEnd objects

### DIFF
--- a/lambda/export/invokable/index.js
+++ b/lambda/export/invokable/index.js
@@ -126,7 +126,8 @@ exports.handler = async (event, context) => {
 async function getAllRecords(queryObj) {
   queryObj.ExpressionAttributeValues = {};
   queryObj.ExpressionAttributeValues[":prefixDate"] = { S: "20" };
-  queryObj.FilterExpression = "begins_with(sk, :prefixDate)";
+  queryObj.ExpressionAttributeValues[":fiscalYearEnd"] = { S: 'fiscalYearEnd'};
+  queryObj.FilterExpression = "begins_with(sk, :prefixDate) AND pk <> :fiscalYearEnd";
   return await runScan(queryObj);
 }
 


### PR DESCRIPTION
`fiscalYearEnd` objects and `record` objects share the same `sk` format (YYYYMM). 

This format is what the exporter uses to pull every record in the system currently, so the `fiscalYearEnd` objects are getting mixed in with the exported records and throwing syntax errors. 

Might need to robustify the `getAllRecords` function in the future now that we have `getParks` and `getSubareas` as helper functions in `dynamoUtils.js`.