### PR TITLE
BRS-502-3: Exporter refactor - avoid pulling fiscalYearEnd objs.

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -151,8 +151,8 @@ async function getSubAreas(orcs) {
 // pass the full subarea object.
 // pass filter = false to look for every possible activity
 async function getRecords(subArea, filter = true) {
-  records = [];
-  filteredActivityList = RECORD_ACTIVITY_LIST;
+  let records = [];
+  let filteredActivityList = RECORD_ACTIVITY_LIST;
   if (filter && subArea.activites) {
     filteredActivityList = AWS.DynamoDB.Converter.unmarshall(subArea.activites);
   }

--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -24,6 +24,16 @@ const PASS_TYPE_EXPIRY_HOURS = {
   DAY: 0,
 };
 
+const RECORD_ACTIVITY_LIST = [
+  'Frontcountry Camping',
+  'Frontcountry Cabins',
+  'Backcountry Camping',
+  'Backcountry Cabins',
+  'Group Camping',
+  'Day Use',
+  'Boating'
+];
+
 const dynamodb = new AWS.DynamoDB(options);
 
 exports.dynamodb = new AWS.DynamoDB();
@@ -33,7 +43,7 @@ async function getOne(pk, sk) {
   logger.debug(`getItem: { pk: ${pk}, sk: ${sk} }`);
   const params = {
     TableName: TABLE_NAME,
-    Key: AWS.DynamoDB.Converter.marshall({pk, sk})
+    Key: AWS.DynamoDB.Converter.marshall({ pk, sk })
   };
   let item = await dynamodb.getItem(params).promise();
   if (item?.Item) {
@@ -137,6 +147,30 @@ async function getSubAreas(orcs) {
   return await runQuery(subAreaQuery);
 }
 
+// returns all records within a subarea.
+// pass the full subarea object.
+// pass filter = false to look for every possible activity
+async function getRecords(subArea, filter = true) {
+  records = [];
+  filteredActivityList = RECORD_ACTIVITY_LIST;
+  if (filter && subArea.activites) {
+    filteredActivityList = AWS.DynamoDB.Converter.unmarshall(subArea.activites);
+  }
+  for (let activity of filteredActivityList) {
+    const recordQuery = {
+      TableName: TABLE_NAME,
+      KeyConditionExpression: `pk = :pk`,
+      ExpressionAttributeValues: {
+        ':pk': { S: `${subArea.sk}::${activity}` },
+      },
+    }
+    // will return at most 1 record.
+    const record = await runQuery(recordQuery);
+    records = records.concat(record);
+  }
+  return records;
+}
+
 module.exports = {
   ACTIVE_STATUS,
   RESERVED_STATUS,
@@ -154,5 +188,6 @@ module.exports = {
   runScan,
   getOne,
   getParks,
-  getSubAreas
+  getSubAreas,
+  getRecords
 };

--- a/lambda/export/invokable/index.js
+++ b/lambda/export/invokable/index.js
@@ -2,7 +2,7 @@ const AWS = require("aws-sdk");
 const s3 = new AWS.S3();
 const fs = require("fs");
 const writeXlsxFile = require("write-excel-file/node");
-const { runScan, runQuery, TABLE_NAME } = require("../../dynamoUtil");
+const { runScan, runQuery, TABLE_NAME, getParks, getSubAreas, getRecords } = require("../../dynamoUtil");
 const {
   EXPORT_NOTE_KEYS,
   EXPORT_MONTHS,
@@ -124,10 +124,22 @@ exports.handler = async (event, context) => {
 };
 
 async function getAllRecords(queryObj) {
-  queryObj.ExpressionAttributeValues = {};
-  queryObj.ExpressionAttributeValues[":prefixDate"] = { S: "20" };
-  queryObj.FilterExpression = "begins_with(sk, :prefixDate)";
-  return await runScan(queryObj);
+  let records = [];
+  let subareas = [];
+  try {
+    const parks = await getParks();
+    for (let park of parks) {
+      const parkSubAreas = await getSubAreas(park.sk)
+      subareas = subareas.concat(parkSubAreas);
+    }
+    for (let subarea of subareas) {
+      const subAreaRecords = await getRecords(subarea, true);
+      records = records.concat(subAreaRecords);
+    }
+    return records;
+  } catch (err) {
+    logger.error(err);
+  }
 }
 
 async function groupBySubAreaAndDate(

--- a/lambda/export/invokable/index.js
+++ b/lambda/export/invokable/index.js
@@ -128,11 +128,11 @@ async function getAllRecords(queryObj) {
   let subareas = [];
   try {
     const parks = await getParks();
-    for (let park of parks) {
-      const parkSubAreas = await getSubAreas(park.sk)
+    for (const park of parks) {
+      const parkSubAreas = await getSubAreas(park.sk);
       subareas = subareas.concat(parkSubAreas);
     }
-    for (let subarea of subareas) {
+    for (const subarea of subareas) {
       const subAreaRecords = await getRecords(subarea, true);
       records = records.concat(subAreaRecords);
     }


### PR DESCRIPTION
`fiscalYearEnd` objects and `record` objects share the same `sk` format (YYYYMM).

This format is what the exporter uses to pull every record in the system currently, so the `fiscalYearEnd` objects are getting mixed in with the exported records and throwing syntax errors.

Added a `getRecords(subAreaObj, filter)` function to `dynamoUtils` to pull all records associated with a provided subarea. This is now the method used to collect all records in the system for the exporter. 