### PR TITLE
BRS-817-2 preventing locking of future dates

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -24,6 +24,8 @@ const PASS_TYPE_EXPIRY_HOURS = {
   DAY: 0,
 };
 
+const FISCAL_YEAR_FINAL_MONTH = 3; // March
+
 const RECORD_ACTIVITY_LIST = [
   'Frontcountry Camping',
   'Frontcountry Cabins',
@@ -181,6 +183,7 @@ module.exports = {
   TIMEZONE,
   PM_ACTIVATION_HOUR,
   PASS_TYPE_EXPIRY_HOURS,
+  FISCAL_YEAR_FINAL_MONTH,
   timeZone,
   TABLE_NAME,
   dynamodb,

--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -12,7 +12,6 @@ if (process.env.IS_OFFLINE) {
 const ACTIVE_STATUS = "active";
 const RESERVED_STATUS = "reserved";
 const EXPIRED_STATUS = "expired";
-const timeZone = "America/Vancouver";
 const PASS_TYPE_AM = "AM";
 const PASS_TYPE_PM = "PM";
 const PASS_TYPE_DAY = "DAY";
@@ -184,7 +183,6 @@ module.exports = {
   PM_ACTIVATION_HOUR,
   PASS_TYPE_EXPIRY_HOURS,
   FISCAL_YEAR_FINAL_MONTH,
-  timeZone,
   TABLE_NAME,
   dynamodb,
   runQuery,

--- a/lambda/fiscalYearEnd/POST/index.js
+++ b/lambda/fiscalYearEnd/POST/index.js
@@ -1,8 +1,9 @@
 const AWS = require('aws-sdk');
-const { TABLE_NAME, dynamodb } = require('../../dynamoUtil');
+const { TABLE_NAME, dynamodb, timeZone, FISCAL_YEAR_FINAL_MONTH } = require('../../dynamoUtil');
 const { sendResponse } = require('../../responseUtil');
 const { logger } = require('../../logger');
 const { decodeJWT, resolvePermissions } = require('../../permissionUtil');
+const { DateTime } = require('luxon');
 
 // lock the fiscal year from further edits
 exports.lockFiscalYear = async (event, context) => {
@@ -19,7 +20,7 @@ async function handleLockUnlock(isLocked, event, context) {
   logger.debug(`POST: ${type} fiscal year`, event);
   try {
     await checkPermissions(event);
-    const params = verifyEventParams(event);
+    const params = verifyEventParams(event, isLocked);
     const res = await putFiscalYear(isLocked, params);
     logger.debug('POST result:', res);
     return sendResponse(200, res);
@@ -41,7 +42,7 @@ async function checkPermissions(event) {
   return permissionObject;
 }
 
-function verifyEventParams(event) {
+function verifyEventParams(event, isLocked) {
   const params = event?.queryStringParameters || null;
   if (!params || !params.fiscalYearEnd) {
     throw {
@@ -49,14 +50,26 @@ function verifyEventParams(event) {
       msg: `Missing parameters. Must provide 'fiscalYearEnd'.`
     };
   }
-  const regex = new RegExp('^[0-9]{4}$');
-  const validYear = regex.test(params.fiscalYearEnd);
-  if (!validYear) {
+  const validYear = DateTime.fromFormat(params.fiscalYearEnd, 'yyyy');
+  if (validYear.invalid) {
     throw {
       code: 400,
       msg: `Invalid fiscal year. Format: 'yyyy'`
     };
   }
+  const today = DateTime.now().setZone(timeZone);
+  const currentFiscalYearEnd = DateTime.fromObject({
+    year: params.fiscalYearEnd,
+    month: FISCAL_YEAR_FINAL_MONTH,
+  }, {
+    zone: timeZone
+  }).endOf('month');
+  if (currentFiscalYearEnd > today && isLocked) {
+    throw {
+      code: 400,
+      msg: `You cannot lock a fiscal year that has not yet concluded.`
+    }
+  } 
   return params;
 }
 

--- a/lambda/fiscalYearEnd/POST/index.js
+++ b/lambda/fiscalYearEnd/POST/index.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const { TABLE_NAME, dynamodb, timeZone, FISCAL_YEAR_FINAL_MONTH } = require('../../dynamoUtil');
+const { TABLE_NAME, dynamodb, TIMEZONE, FISCAL_YEAR_FINAL_MONTH } = require('../../dynamoUtil');
 const { sendResponse } = require('../../responseUtil');
 const { logger } = require('../../logger');
 const { decodeJWT, resolvePermissions } = require('../../permissionUtil');
@@ -57,12 +57,12 @@ function verifyEventParams(event, isLocked) {
       msg: `Invalid fiscal year. Format: 'yyyy'`
     };
   }
-  const today = DateTime.now().setZone(timeZone);
+  const today = DateTime.now().setZone(TIMEZONE);
   const currentFiscalYearEnd = DateTime.fromObject({
     year: params.fiscalYearEnd,
     month: FISCAL_YEAR_FINAL_MONTH,
   }, {
-    zone: timeZone
+    zone: TIMEZONE
   }).endOf('month');
   if (currentFiscalYearEnd > today && isLocked) {
     throw {


### PR DESCRIPTION
According to https://bcparksdigital.atlassian.net/browse/BRS-817, we need to prevent users from locking records & fiscal years if the month/fiscal year the record is in has not yet concluded.

This change includes the API changes to support this.