### PR TITLE
NOBUG - updating Actions to use Node16

### DIFF
--- a/.github/workflows/PR-Tests.yml
+++ b/.github/workflows/PR-Tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/