### PR TITLE
BRS-849-2 ensuring jobObj backwards compatibility

### DIFF
--- a/lambda/export/GET/index.js
+++ b/lambda/export/GET/index.js
@@ -111,7 +111,7 @@ exports.handler = async (event, context) => {
           ":error": { S: 'error' }
         },
         ConditionExpression:
-          "(attribute_not_exists(pk) AND attribute_not_exists(sk)) OR progressState = :complete OR progressState = :error",
+          "(attribute_not_exists(pk) AND attribute_not_exists(sk)) OR attribute_not_exists(progressState) OR progressState = :complete OR progressState = :error",
         Item: AWS.DynamoDB.Converter.marshall({
           pk: "job",
           sk: sk,


### PR DESCRIPTION
https://bcparksdigital.atlassian.net/browse/BRS-849

The attribute `jobObj.progressState` was introduced on this ticket. Since this attribute does not exist on old job objects, a conditional expression was failing. 

This code ensures the new code is backwards compatible with old exporter job objects. 