### PR TITLE
BRS-971-3: ensuring front-end filters out legacy data (for now).

### DIFF
--- a/__tests__/global/data.json
+++ b/__tests__/global/data.json
@@ -25,6 +25,18 @@
       ],
       "pk": "park",
       "parkName": "Cowichan River Park"
+    },
+    {
+      "sk": "HIST",
+      "subAreas": [
+        {
+          "name": "LEGACY SUBAREA",
+          "id": "HIST"
+        }
+      ],
+      "pk": "park",
+      "isLegacy": true,
+      "parkName": "LEGACY PARK"
     }
   ],
   "SUBAREA_INFORMATION": [
@@ -78,6 +90,23 @@
       ],
       "orcs": "6161",
       "subAreaName": "Holt Creek"
+    },
+    {
+      "pk": "park::HIST",
+      "sk": "HIST",
+      "isLegacy": true,
+      "activities": [
+        "Frontcountry Camping",
+        "Frontcountry Cabins",
+        "Backcountry Camping",
+        "Backcountry Cabins",
+        "Group Camping",
+        "Day Use",
+        "Boating",
+        "Legacy Data"
+      ],
+      "orcs": "HIST",
+      "subAreaName": "LEGACY SUBAREA"
     }
   ],
   "SUBAREA_ENTRIES": [
@@ -134,6 +163,20 @@
       "subAreaName": "Maple Bay",
       "orcs": "0041",
       "notes": "This one should be locked directly",
+      "isLocked": false
+    },
+    {
+      "pk": "HIST::Legacy Data",
+      "sk": "202303",
+      "isLegacy": true,
+      "parkName": "LEGACY PARK",
+      "subAreaName": "LEGACY SUBAREA",
+      "orcs": "HIST",
+      "legacyData": {
+        "legacy_totalsTotalAttendancePeople": 1123,
+        "legacy_dataSource": "I made it up"
+      },
+      "notes": "Legacy record for legacy data that doesn't fit into another activity",
       "isLocked": false
     }
   ],

--- a/__tests__/park.test.js
+++ b/__tests__/park.test.js
@@ -57,8 +57,15 @@ describe("Pass Succeeds", () => {
       },
       httpMethod: "GET",
     };
+    // Ignore legacy parks for now.
+    let modifiedParksList = [...PARKSLIST];
+    for (const [index, park] of modifiedParksList.entries()) {
+      if (park.hasOwnProperty('isLegacy')) {
+        modifiedParksList.splice(index, 1);
+      }
+    }
     expect(await parkGET.handler(event, null)).toMatchObject({
-      body: JSON.stringify(PARKSLIST),
+      body: JSON.stringify(modifiedParksList),
       headers: {
         "Access-Control-Allow-Headers":
           "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",

--- a/lambda/park/GET/index.js
+++ b/lambda/park/GET/index.js
@@ -25,8 +25,9 @@ exports.handler = async (event, context) => {
       // Get me a list of parks, with subareas
       queryObj.ExpressionAttributeValues = {};
       queryObj.ExpressionAttributeValues[':pk'] = { S: 'park' };
+      queryObj.ExpressionAttributeValues[':isLegacy'] = { BOOL: false };
       queryObj.KeyConditionExpression = 'pk =:pk';
-
+      queryObj.FilterExpression = 'attribute_not_exists(isLegacy) OR isLegacy = :isLegacy';
       let results = [];
       let parkData;
       do {


### PR DESCRIPTION
### Jira Ticket:
BRS-971

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-971

### Description:
This change ensures that legacy data is not returned by the API (for now). We do not have the front end set up in a way that can handle legacy parks/subareas/records yet. 

Updated UT mock data items to include legacy instances to ensure all tests still pass. 
