### PR TITLE
BRS-897: Adds utility class for keycloak administrative functions.  U…

### DIFF
--- a/__tests__/keycloakUtil.test.js
+++ b/__tests__/keycloakUtil.test.js
@@ -1,0 +1,72 @@
+
+describe("keycloak utility tests", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+  });
+
+  test("Creates keycloak role", async () => {
+    const axios = require('axios');
+    jest.mock("axios");
+    axios.post.mockImplementation(() => Promise.resolve({ statusCode: 200, data: {} }));
+    const utils = require("../lambda/keycloakUtil");
+    const response = await utils.createKeycloakRole('http://localhost/', 'client-id', 'sometoken', '0001:0001', 'Some description');
+    expect(response).toEqual({});
+  });
+
+  test("Fails to create keycloak role", async () => {
+    const axios = require('axios');
+    jest.mock("axios");
+    axios.post.mockImplementation(() => Promise.reject({ statusCode: 400, data: {} }));
+    const utils = require("../lambda/keycloakUtil");
+    try {
+      await utils.createKeycloakRole('http://localhost/', 'client-id', 'sometoken', '0001:0001', 'Some description');
+    } catch (error) {
+      expect(error.message).toEqual('Operation Failed.');
+    }
+  });
+
+  test("Deletes keycloak role", async () => {
+    const axios = require('axios');
+    jest.mock("axios");
+    axios.delete.mockImplementation(() => Promise.resolve({ statusCode: 200, data: { } }));
+    const utils = require("../lambda/keycloakUtil");
+    const response = await utils.deleteKeycloakRole('http://localhost/', 'client-id', 'sometoken', '0001:0001');
+    expect(response).toEqual({});
+  });
+
+  test("Fails to delete keycloak role", async () => {
+    const axios = require('axios');
+    jest.mock("axios");
+    axios.delete.mockImplementation(() => Promise.reject({ statusCode: 400, data: {} }));
+    const utils = require("../lambda/keycloakUtil");
+    try {
+      await utils.deleteKeycloakRole('http://localhost/', 'client-id', 'sometoken', '0001:0001', 'Some description');
+    } catch (error) {
+      expect(error.message).toEqual('Operation Failed.');
+    }
+  });
+
+  test("Gets keycloak role", async () => {
+    const theRole = {
+      name: 'some role'
+    };
+    const axios = require('axios');
+    jest.mock("axios");
+    axios.get.mockImplementation(() => Promise.resolve({ statusCode: 200, data: theRole }));
+    const utils = require("../lambda/keycloakUtil");
+    const response = await utils.getKeycloakRole('http://localhost/', 'client-id', 'sometoken', '0001:0001');
+    expect(response).toEqual(theRole);
+  });
+
+  test("Fails to get keycloak role", async () => {
+    const axios = require('axios');
+    jest.mock("axios");
+    axios.get.mockImplementation(() => Promise.reject({ statusCode: 400, data: {} }));
+    const utils = require("../lambda/keycloakUtil");
+    try {
+      await utils.getKeycloakRole('http://localhost/', 'client-id', 'sometoken', '0001:0001');
+    } catch (error) {
+      expect(error.message).toEqual('Operation Failed.');
+    }
+  });
+});

--- a/lambda/keycloakUtil.js
+++ b/lambda/keycloakUtil.js
@@ -1,0 +1,98 @@
+const axios = require('axios');
+const { mainModule } = require('process');
+const { logger } = require("./logger");
+
+const config = {
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+  }
+};
+
+/**
+ * Creates a new role in the specified Keycloak realm's client.
+ * @async
+ * @function createKeycloakRole
+ * @param {string} ssoURL - The URL of the Keycloak server.
+ * @param {string} ssoClientID - The ID of the client in the Keycloak realm.
+ * @param {string} token - An access token for authentication.
+ * @param {string} role - The name of the new role.
+ * @param {string=} description - An optional description for the new role.
+ * @returns {Promise<AxiosResponse>} The HTTP response from the server.
+ * @throws {Error} If the operation fails.
+ */
+createKeycloakRole = async function (ssoURL, ssoClientID, token, role, description) {
+  const url = `${ssoURL}/auth/admin/realms/bcparks-service-transformation/clients/${ssoClientID}/roles`;
+  const postBody = {
+    "name": `${role}`,
+    "composite": false,
+    "clientRole": true,
+    "description": description
+  };
+  try {
+    logger.info('Calling Keycloak Service');
+    const res = await axios.post(url,
+                                 postBody,
+                                 { ...config, headers: { ...config.headers, 'Authorization': 'Bearer ' + token }});
+    return res.data;
+  } catch (error) {
+    logger.error(error);
+    throw new Error('Operation Failed.')
+  }
+};
+
+
+/**
+ * Deletes an existing role from the specified Keycloak realm's client.
+ * @async
+ * @function deleteKeycloakRole
+ * @param {string} ssoURL - The URL of the Keycloak server.
+ * @param {string} ssoClientID - The ID of the client in the Keycloak realm.
+ * @param {string} token - An access token for authentication.
+ * @param {string} role - The name of the role to be deleted.
+ * @returns {Promise<AxiosResponse>} The HTTP response from the server.
+ * @throws {Error} If the operation fails.
+ */
+deleteKeycloakRole = async function (ssoURL, ssoClientID, token, role) {
+  const url = `${ssoURL}/auth/admin/realms/bcparks-service-transformation/clients/${ssoClientID}/roles/${role}`;
+  try {
+    logger.info('Calling Keycloak Service');
+    const res = await axios.delete(url,
+                                  { ...config, headers: { ...config.headers, 'Authorization': 'Bearer ' + token } });
+    return res.data;
+  } catch (error) {
+    logger.error(error);
+    throw new Error('Operation Failed.')
+  }
+}
+
+
+/**
+ * Retrieves information about an existing role from the specified Keycloak realm's client.
+ * @async
+ * @function getKeycloakRole
+ * @param {string} ssoURL - The URL of the Keycloak server.
+ * @param {string} ssoClientID - The ID of the client in the Keycloak realm.
+ * @param {string} token - An access token for authentication.
+ * @param {string} role - The name of the role to be retrieved.
+ * @returns {Promise<AxiosResponse>} The HTTP response from the server.
+ * @throws {Error} If the operation fails.
+ */
+getKeycloakRole = async function (ssoURL, ssoClientID, token, role) {
+  const url = `${ssoURL}/auth/admin/realms/bcparks-service-transformation/clients/${ssoClientID}/roles/${role}`;
+  try {
+    logger.info('Calling Keycloak Service');
+    const res = await axios.get(url,
+                                { ...config, headers: { ...config.headers, 'Authorization': 'Bearer ' + token } });
+    return res.data;
+  } catch (error) {
+    logger.error(error);
+    throw new Error('Operation Failed.')
+  }
+}
+
+module.exports = {
+  getKeycloakRole,
+  deleteKeycloakRole,
+  createKeycloakRole
+};

--- a/postman/A&R - DEV.postman_environment.json
+++ b/postman/A&R - DEV.postman_environment.json
@@ -43,7 +43,13 @@
 			"value": "a&r_token_dev",
 			"type": "default",
 			"enabled": true
-		}
+		},
+    {
+      "key": "keycloak_client_url",
+      "value": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/bcparks-service-transformation/clients/e530debc-b4e0-417a-947d-2907d70404da",
+      "type": "default",
+      "enabled": true
+    }
 	],
 	"_postman_variable_scope": "environment",
 	"_postman_exported_at": "2022-09-21T23:26:44.871Z",

--- a/postman/A&R - LOCAL.postman_environment.json
+++ b/postman/A&R - LOCAL.postman_environment.json
@@ -43,7 +43,13 @@
 			"value": "a&r_token_local",
 			"type": "default",
 			"enabled": true
-		}
+		},
+    {
+      "key": "keycloak_client_url",
+      "value": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/bcparks-service-transformation/clients/e530debc-b4e0-417a-947d-2907d70404da",
+      "type": "default",
+      "enabled": true
+    }
 	],
 	"_postman_variable_scope": "environment",
 	"_postman_exported_at": "2022-09-21T23:26:31.585Z",

--- a/postman/A&R - TEST.postman_environment.json
+++ b/postman/A&R - TEST.postman_environment.json
@@ -43,7 +43,13 @@
 			"value": "a&r_token_test",
 			"type": "default",
 			"enabled": true
-		}
+		},
+    {
+      "key": "keycloak_client_url",
+      "value": "https://test.loginproxy.gov.bc.ca/auth/admin/realms/bcparks-service-transformation/clients/2246a87f-96b7-4907-ba54-6202339560a1",
+      "type": "default",
+      "enabled": true
+    }
 	],
 	"_postman_variable_scope": "environment",
 	"_postman_exported_at": "2022-09-21T23:26:50.491Z",

--- a/postman/BCParks Attendance and Revenue.postman_collection.json
+++ b/postman/BCParks Attendance and Revenue.postman_collection.json
@@ -324,7 +324,72 @@
 					"response": []
 				}
 			]
-		}
+		},
+    {
+      "name": "KeyCloak",
+      "item": [
+        {
+          "name": "All Roles",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "Get Specific Role",
+          "request": {
+            "method": "GET",
+            "header": []
+          },
+          "response": []
+        },
+        {
+          "name": "Create Role",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\r\n    \"name\": \"0001:0001\",\r\n    \"composite\": false,\r\n    \"clientRole\": true,\r\n    \"description\": \"Strathcona Park:New Subarea Name\"\r\n  }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{keycloak_client_url}}/roles",
+              "host": [
+                "{{keycloak_client_url}}"
+              ],
+              "path": [
+                "roles"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Role",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{keycloak_client_url}}/roles/0001:0001",
+              "host": [
+                "{{keycloak_client_url}}"
+              ],
+              "path": [
+                "roles",
+                "0001:0001"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
 	],
 	"auth": {
 		"type": "oauth2",

--- a/terraform/src/park.tf
+++ b/terraform/src/park.tf
@@ -17,6 +17,7 @@ resource "aws_lambda_function" "parkGetLambda" {
     variables = {
       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}",
       SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_ORIGIN  = data.aws_ssm_parameter.sso_origin.value,
       SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
       LOG_LEVEL   = "info"
     }
@@ -41,6 +42,7 @@ resource "aws_lambda_function" "parkPostLambda" {
   environment {
     variables = {
       SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_ORIGIN  = data.aws_ssm_parameter.sso_origin.value,
       SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}",
       LOG_LEVEL   = "info"

--- a/terraform/src/subarea.tf
+++ b/terraform/src/subarea.tf
@@ -19,6 +19,7 @@
 #   environment {
 #     variables = {
 #       SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+#       SSO_ORIGIN  = data.aws_ssm_parameter.sso_origin.value,
 #       SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
 #       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}",
 #       LOG_LEVEL   = "info"
@@ -59,6 +60,7 @@
 #   environment {
 #     variables = {
 #       SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+#       SSO_ORIGIN  = data.aws_ssm_parameter.sso_origin.value,
 #       SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
 #       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}",
 #       LOG_LEVEL   = "info"
@@ -99,6 +101,7 @@
 #   environment {
 #     variables = {
 #       SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+#       SSO_ORIGIN  = data.aws_ssm_parameter.sso_origin.value,
 #       SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
 #       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}",
 #       LOG_LEVEL   = "info"
@@ -139,6 +142,7 @@
 #   environment {
 #     variables = {
 #       SSO_ISSUER  = data.aws_ssm_parameter.sso_issuer.value,
+#       SSO_ORIGIN  = data.aws_ssm_parameter.sso_origin.value,
 #       SSO_JWKSURI = data.aws_ssm_parameter.sso_jwksuri.value,
 #       TABLE_NAME  = "${data.aws_ssm_parameter.db_name.value}-${random_string.postfix.result}",
 #       LOG_LEVEL   = "info"

--- a/terraform/src/variables.tf
+++ b/terraform/src/variables.tf
@@ -31,6 +31,14 @@ data "aws_ssm_parameter" "sso_issuer" {
   name = "/parks-ar-api/sso-issuer"
 }
 
+data "aws_ssm_parameter" "sso_origin" {
+  name = "/parks-ar-api/sso-origin"
+}
+
 data "aws_ssm_parameter" "sso_jwksuri" {
   name = "/parks-ar-api/sso-jwksuri"
+}
+
+data "aws_ssm_parameter" "keycloak_client_id" {
+  name = "/parks-ar-api/keycloak-client-id"
 }


### PR DESCRIPTION
…ser *MUST* have realm admin on their user account.

### Jira Ticket:
BRS-897

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-897

### Description:
This adds a utility module for interacting with a Keycloak server. It exports three functions: `getKeycloakRole`, `deleteKeycloakRole`, and `createKeycloakRole`.

`createKeycloakRole` function creates a new role in the specified Keycloak realm's client. It takes in parameters such as the Keycloak server URL, client ID, access token for authentication, and the name and description of the new role. It returns a promise that resolves to an AxiosResponse object that contains the HTTP response from the server.

`deleteKeycloakRole` function deletes an existing role from the specified Keycloak realm's client. It takes in parameters such as the Keycloak server URL, client ID, access token for authentication, and the name of the role to be deleted. It returns a promise that resolves to an AxiosResponse object that contains the HTTP response from the server.

`getKeycloakRole` function retrieves information about an existing role from the specified Keycloak realm's client. It takes in parameters such as the Keycloak server URL, client ID, access token for authentication, and the name of the role to be retrieved. It returns a promise that resolves to an AxiosResponse object that contains the HTTP response from the server.

Example calls are as follows (sub clientID and keycloak token for the appropriate environment): 
```
  await this.createKeycloakRole('https://dev.loginproxy.gov.bc.ca', <clientID>, <keycloak token>, '0001:0403', 'Some new thing')
  await this.getKeycloakRole('https://dev.loginproxy.gov.bc.ca', <clientID>, <keycloak token>, '0001:0403')
  await this.deleteKeycloakRole('https://dev.loginproxy.gov.bc.ca', <clientID>, <keycloak token>, '0001:0403')
```

Note: Parameter store values have been seeded in all environments.  

`data.aws_ssm_parameter.sso_origin` and `data.aws_ssm_parameter.keycloak_client_id` are available for lambda function env var usage with the former already setup for park/subarea endpoints.

This enables users to find the SSO origin address, as well 