### PR TITLE
BRS-1115: upping exporter timeout (temp)

### DIFF
--- a/terraform/src/export.tf
+++ b/terraform/src/export.tf
@@ -9,7 +9,7 @@ resource "aws_lambda_function" "exportInvokableLambda" {
   runtime = "nodejs14.x"
   publish = "true"
 
-  timeout = 120
+  timeout = 300
   memory_size = 2048
 
   environment {


### PR DESCRIPTION
### Jira Ticket:
BRS-1115

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1115

### Description:
Improving timeout for `export-invokable` following a 120s timeout being too short.
Note: improving memory did not improve lambda time.
- 2048 MB = 110s run time
- 8192 MB = 107s run time
A more permanent solution will be handled in a future ticket (BRS-1118).