### PR TITLE
NOBUG - mislabelled historical data item in schema

### DIFF
--- a/migrations-data/legacy-data/legacy-data-constants.js
+++ b/migrations-data/legacy-data/legacy-data-constants.js
@@ -448,7 +448,7 @@ const schema = {
     type: Number,
     activity: activitiesEnum[1],
     hasMatch: true,
-    fieldMap: 'otherRevenueGrossSani',
+    fieldMap: 'otherRevenueShower',
     fieldName: 'Frontcountry Camping - Other - Gross shower revenue'
   },
   'Net Shower Revenue': {


### PR DESCRIPTION
### Jira Ticket:
NOBUG

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-971

### Description:
In the schema that controls field mapping in the historical data migrations, under Frontcountry Camping, the field for 'Gross Shower Revenue' erroneously points to `otherRevenueGrossSani` values.

**What does this mean?**
In `dev` and `test` which have already had the migrations performed on them, historical values for  `otherRevenueGrossSani` may have been replaced with values for `otherRevenueShower`, and fields relying on `otherRevenueShower` values will be blank.

Prod is unaffected as the migration has not been run yet.

**Does that mean `dev` and `test` are completely borked?**
No, aside from the errors in historical data above. New system records and newly created records are unaffected, and it wouldn't be a good use of developer time right now to fix these errors as they are extremely minor.
