### PR TITLE
BRS-1191: Adding data model and wiring up POST activity with calculat…

### DIFF
--- a/__tests__/variance.test.js
+++ b/__tests__/variance.test.js
@@ -202,7 +202,7 @@ describe("Variance Test", () => {
     expect(response.body === "{ msg: 'Invalid request.' }");
   });
 
-  test("Variance should triggered", async () => {
+  test("Variance should trigger", async () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance(8, 8, 8, 10, 0.2);
     expect(res).toEqual({
@@ -212,7 +212,7 @@ describe("Variance Test", () => {
     });
   });
 
-  test("Variance should not triggered", async () => {
+  test("Variance should not trigger", async () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance(10, 10, 10, 10, 0.2);
     expect(res).toEqual({

--- a/lambda/activity/POST/index.js
+++ b/lambda/activity/POST/index.js
@@ -11,9 +11,11 @@ const { sendResponse } = require("../../responseUtil");
 const { decodeJWT, resolvePermissions } = require("../../permissionUtil");
 const { logger } = require("../../logger");
 const { DateTime } = require("luxon");
+const { calculateVariance } = require('../../varianceUtils');
+const { EXPORT_VARIANCE_CONFIG } = require("../../constants");
 
 exports.handlePost = async (event, context) => {
-  logger.debug("Activity POST:", event);
+  logger.info("Activity POST:");
   return await main(event, context);
 };
 
@@ -39,11 +41,9 @@ async function main(event, context, lock = null) {
 
     const body = JSON.parse(event.body);
 
-    if (
-      !permissionObject.isAdmin &&
-      permissionObject.roles.includes(`${body.orcs}:${body.subAreaId}`) ===
-        false
-    ) {
+    if (!permissionObject.isAdmin
+        && permissionObject.roles.includes(`${body.orcs}:${body.subAreaId}`) === false)
+    {
       logger.info("Not authorized.");
       logger.debug(permissionObject.roles);
       return sendResponse(403, { msg: "Unauthorized." }, context);
@@ -108,11 +108,154 @@ async function main(event, context, lock = null) {
       // fall through and create new record for locking.
       lock = true;
     }
-    return await handleActivity(body, lock, context);
+
+    if (event?.queryStringParameters?.isForced  == 'true') {
+      return await handleActivity(body, lock, context);
+    } else {
+      return await handleVarianceTrigger(body, lock, context);
+    }
   } catch (err) {
     logger.error(err);
     return sendResponse(400, { msg: "Invalid request" }, context);
   }
+}
+
+async function handleVarianceTrigger(body, lock, context) {
+  // Check for variances.  If true, create a variance trigger, and if not, checks
+  // if there is an existing trigger and deletes it before returning.
+  try {
+    await checkVarianceTrigger(body);
+  } catch (e) {
+    // Something blew up checking the variance.
+    // TBD: What should we do?  For now fall-through.
+    logger.error(e);
+  }
+  logger.info("Adding activity record:", body);
+  return await handleActivity(body, lock, context);
+}
+
+async function deleteVariance(subAreaId, activity, date) {
+  const params = {
+    TableName: TABLE_NAME,
+    Key: {
+      pk: { S: `variance::${subAreaId}::${activity}` },
+      sk: { S: date }
+    }
+  };
+
+  logger.info("Deleting variance record:", params);
+
+  await dynamodb.deleteItem(params).promise();
+}
+
+async function checkVarianceTrigger(body) {
+  const subAreaId   = body.subAreaId;
+  const activity    = body.activity;
+  const date        = body.date;
+  const note        = body.note;
+  const orcs        = body.orcs;
+  const subAreaName = body.subAreaName;
+  const parkName    = body.parkName;
+
+  // Create a variance field array
+  let fields = [];
+  let varianceWasTriggered = false;
+
+  // Map through all fields we care about and check their values
+  let varianceConfig = EXPORT_VARIANCE_CONFIG[activity];
+  const fieldsToCheck = Object.keys(varianceConfig);
+
+  logger.info(`Fields to check: ${fieldsToCheck}`);
+
+  // Pull up to the last 3 years for this activity type and date.
+  let records = await getPreviousYearData(3, subAreaId, activity, date);
+
+  for (const field in fieldsToCheck) {
+    logger.info(`Checking ${fieldsToCheck[field]}`);
+    let current = body?.[fieldsToCheck[field]];
+    let first = records[0]?.[fieldsToCheck[field]];
+    let second = records[1]?.[fieldsToCheck[field]];
+    let third = records[2]?.[fieldsToCheck[field]];
+
+    // Grabs the field percentage from the object
+    logger.info(`Calculating variance ${first}, ${second}, ${third}, ${current}, ${varianceConfig[fieldsToCheck[field]]}`);
+
+    if (!current || !first) {
+      // We couldn't pull any records for this date
+      logger.info('No records found - cleaning up existing variance records.');
+      await deleteVariance(subAreaId, activity, date);
+      return;
+    }
+
+    const res = calculateVariance(first, second, third, current, varianceConfig[fieldsToCheck[field]]);
+    if (res.varianceTriggered) {
+      varianceWasTriggered = true;
+      fields.push(fieldsToCheck[field]);
+    }
+  }
+  // By now, the varianceWasTriggered should be active and the fields array full
+  // of the specific fields that triggers.  Or, there is no variance at all.
+  logger.info('Variance triggered: ', varianceWasTriggered);
+  logger.info(fields);
+
+  if (varianceWasTriggered) {
+    await createVariance(subAreaId, activity, date, fields, note, orcs, parkName, subAreaName);
+  } else {
+    // Attempt to delete any previous variances
+    await deleteVariance(subAreaId, activity, date);
+  }
+}
+
+async function createVariance(subAreaId, activity, date, fields, note, orcs, parkName, subAreaName) {
+  logger.info('Creating Variance:', subAreaId, activity, date, fields, note)
+  try {
+    const newObject = {
+      pk:`variance::${subAreaId}::${activity}`,
+      sk: date,
+      fields: fields,
+      note: note,
+      resolved: false,
+      orcs: orcs,
+      parkName: parkName,
+      subAreaName: subAreaName
+    };
+    const putObj = {
+      TableName: TABLE_NAME,
+      Item: AWS.DynamoDB.Converter.marshall(newObject),
+    };
+    await dynamodb.putItem(putObj).promise();
+  } catch (e) {
+    logger.error(e);
+  }
+}
+
+async function getPreviousYearData(years, subAreaId, activity, date) {
+  logger.info('Getting previous year data', years, subAreaId, activity, date)
+  // Get records for up to the past N years, limited to no farther than 2011
+  let currentDate = DateTime.fromFormat(date, 'yyyyMM');
+  const targetYear = 2022;
+  let records = [];
+
+  // Go back 3 years until no more than 2022
+  for (let i = 0; i < years && currentDate.year >= targetYear; i++) {
+    let selectedYear = currentDate.toFormat('yyyyMM');
+    logger.info(`Selected year: ${selectedYear}`);
+
+    try {
+      const data = await getOne(`${subAreaId}::${activity}`, selectedYear);
+      logger.info('Read Activity Record Returning.');
+      logger.debug("DATA:", data);
+      if (Object.keys(data).length !== 0) {
+        records.push(data);
+      }
+    } catch (err) {
+      // Skip on errors
+      logger.error(err);
+    }
+    currentDate = currentDate.minus({ years: 1 });
+  }
+
+  return records;
 }
 
 async function checkFiscalYearLock(body) {

--- a/lambda/constants.js
+++ b/lambda/constants.js
@@ -8,6 +8,63 @@ const EXPORT_NOTE_KEYS = {
   Boating: "notes_boating",
 };
 
+const EXPORT_VARIANCE_CONFIG = {
+  'Backcountry Cabins': {
+    peopleAdult: 0.2,
+    peopleChild: 0.2,
+    peopleFamily: 0.2,
+    revenueFamily: 0.2,
+  },
+  'Backcountry Camping': {
+    people: 0.2,
+    grossCampingRevenue: 0.2,
+  },
+  'Boating': {
+    boatAttendanceNightsOnDock: 0.2,
+    boatAttendanceNightsOnBouys: 0.2,
+    boatAttendanceMiscellaneous: 0.2,
+    boatRevenueGross: 0.2,
+  },
+  'Day Use': {
+    peopleAndVehiclesTrail: 0.2,
+    peopleAndVehiclesVehicle: 0.2,
+    peopleAndVehiclesBus: 0.2,
+    picnicRevenueShelter: 0.2,
+    picnicShelterPeople: 0.2,
+    picnicRevenueGross: 0.2,
+    otherDayUsePeopleHotSprings: 0.2,
+    otherDayUseRevenueHotSprings: 0.2,
+  },
+  'Frontcountry Cabins': {
+    totalAttendanceParties: 0.2,
+    revenueGrossCamping: 0.2,
+  },
+  'Frontcountry Camping': {
+    campingPartyNightsAttendanceStandard: 0.2,
+    campingPartyNightsAttendanceSenior: 0.2,
+    campingPartyNightsAttendanceSocial: 0.2,
+    campingPartyNightsAttendanceLongStay: 0.2,
+    campingPartyNightsRevenueGross: 0.2,
+    secondCarsAttendanceStandard: 0.2,
+    secondCarsAttendanceSenior: 0.2,
+    secondCarsAttendanceSocial: 0.2,
+    secondCarsRevenueGross: 0.2,
+    otherRevenueGrossSani: 0.2,
+    otherRevenueElectrical: 0.2,
+    otherRevenueShower: 0.2,
+  },
+  'Group Camping': {
+    standardRateGroupsTotalPeopleStandard: 0.2,
+    standardRateGroupsTotalPeopleAdults: 0.2,
+    standardRateGroupsTotalPeopleYouth: 0.2,
+    standardRateGroupsTotalPeopleKids: 0.2,
+    standardRateGroupsRevenueGross: 0.2,
+    youthRateGroupsAttendanceGroupNights: 0.2,
+    youthRateGroupsAttendancePeople: 0.2,
+    youthRateGroupsRevenueGross: 0.2,
+  },
+};
+
 const EXPORT_MONTHS = {
   "01": "Jan",
   "02": "Feb",
@@ -671,6 +728,7 @@ const CSV_SYSADMIN_SCHEMA = [
 
 module.exports = {
   EXPORT_NOTE_KEYS,
+  EXPORT_VARIANCE_CONFIG,
   EXPORT_MONTHS,
   CSV_SYSADMIN_SCHEMA,
   STATE_DICTIONARY,

--- a/lambda/varianceUtils.js
+++ b/lambda/varianceUtils.js
@@ -37,7 +37,9 @@ function calculateVariance(
   // If negative, variance is triggered
   let varianceTriggered =
     variancePercentage - percentageChangeAbs < 0 ? true : false;
-  logger.debug("Variance triggered?", varianceTriggered);
+  logger.info("Variance percentageChangeAbs?", percentageChangeAbs);
+  logger.info("Variance variancePercentage?", variancePercentage);
+  logger.info("Variance 3?", percentageChangeAbs < 0);
 
   const res = {
     varianceMessage: varianceMessage,


### PR DESCRIPTION
…ion logic.

### Jira Ticket:
BRS-1191

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1191

### Description:
This adds adjustments to the Activity POST endpoint to calculate variances of the past 3 years up to the target year of 2022.  All activity properties can have differing % variance that they check for.

NB: The front-end will need to pass a few more parameters to the activity post, namely orcs, subAreaName, and parkName at a minimum.  See https://github.com/bcgov/bcparks-ar-admin/pull/235 for related update.

Testing:
Push a historical record for 2022 with some sample data, and then add a 2023 record that has/does not have variances beyond 20%. A variance record will be created in variance conditions, or if the activity is forced, it will skip logic. Note the following is not a complete model representation.

e.g.:
```
{
    "date": "202209",
    "subAreaId": "TEST",
    "activity": "Backcountry Camping",
    "people": 3,
    "grossCampingRevenue": 50,
    "orcs": "0001",
    "parkName": "Some Park",
    "subAreaName": "TEST Subarea"
}
```

Will create a previous year data seeding the normal values.  Adding the following will create a variance:

```
{
    "date": "202309",
    "subAreaId": "TEST",
    "activity": "Backcountry Camping",
    "people": 3,
    "grossCampingRevenue": 5000,
    "orcs": "0001",
    "parkName": "Some Park",
    "subAreaName": "TEST Subarea"
}
```
