### PR TITLE
BRS-1214 pt1: Updating API to handle new variance data model

### DIFF
--- a/__tests__/activity.test.js
+++ b/__tests__/activity.test.js
@@ -223,8 +223,8 @@ describe("Activity Test", () => {
     const doc = await docClient.get({
       TableName: TABLE_NAME,
       Key: {
-        pk: `variance::${SUBAREA_ENTRIES[0].pk.split("::")[0]}::${SUBAREA_ENTRIES[0].pk.split("::")[1]}`,
-        sk: "202201"
+        pk: `variance::${SUBAREA_ENTRIES[0].orcs}::202201`,
+        sk: `${SUBAREA_ENTRIES[0].pk.split("::")[0]}}::${SUBAREA_ENTRIES[0].pk.split("::")[1]}`
       },
     }).promise();
     expect(doc).toEqual({});
@@ -260,18 +260,21 @@ describe("Activity Test", () => {
     const doc2 = await docClient.get({
       TableName: TABLE_NAME,
       Key: {
-        pk: `variance::${SUBAREA_ENTRIES[0].pk.split("::")[0]}::${SUBAREA_ENTRIES[0].pk.split("::")[1]}`,
-        sk: "202301"
+        pk: `variance::${SUBAREA_ENTRIES[0].orcs}::202301`,
+        sk: `${SUBAREA_ENTRIES[0].pk.split("::")[0]}::${SUBAREA_ENTRIES[0].pk.split("::")[1]}`
       },
     }).promise();
     expect(doc2.Item).toEqual({
       parkName: 'Cultus Lake Park',
       orcs: '0041',
-      sk: '202301',
-      pk: 'variance::0087::Day Use',
+      sk: '0087::Day Use',
+      pk: 'variance::0041::202301',
       fields: ['picnicRevenueGross'],
       resolved: false,
-      subAreaName: 'TBD'
+      subAreaId: '0087',
+      roles: [ 'sysadmin', '0041:0087'],
+      subAreaName: 'TBD',
+      bundle: 'N/A'
     });
   });
 


### PR DESCRIPTION
### Jira Ticket:
BRS-1214

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1214

### Description:
Updating the API to handle the new variance data model: 

```
pk: variance::<ORCS>::<activityDate>  // activityDate = YYYYMM
sk: <subAreaId::activity
```

Done this way to accommodate the desired search characteristics in the front end. 

Bundles are temporal and do not necessarily remain consistent RE: which parks and subareas they affect so this filter was dropped from consideration. Now a user must know at minimum the `park` and `date` they are searching for. This shards the database in a way that gives high cardinality and fast responses as the database scales in size. 

Roles are now enforced on Variance GET/PUT. 

Filtering by variance `resolved` status is now supported. 

The old data model hasnt landed in PROD yet so no migration needed to convert existing items. 
