### PR TITLE
BRS-1198 pt 1: adding percentageChange to variance object

### DIFF
--- a/__tests__/activity.test.js
+++ b/__tests__/activity.test.js
@@ -269,7 +269,10 @@ describe("Activity Test", () => {
       orcs: '0041',
       sk: '0087::Day Use',
       pk: 'variance::0041::202301',
-      fields: ['picnicRevenueGross'],
+      fields: [{
+        key: 'picnicRevenueGross',
+        percentageChange: 99.1
+      }],
       resolved: false,
       subAreaId: '0087',
       roles: [ 'sysadmin', '0041:0087'],

--- a/lambda/activity/POST/index.js
+++ b/lambda/activity/POST/index.js
@@ -201,7 +201,7 @@ async function checkVarianceTrigger(body) {
     const res = calculateVariance([first, second, third], current, varianceConfig[fieldsToCheck[field]]);
     if (res.varianceTriggered) {
       varianceWasTriggered = true;
-      fields.push(fieldsToCheck[field]);
+      fields.push({key: fieldsToCheck[field], percentageChange: res?.percentageChange});
     }
   }
   // By now, the varianceWasTriggered should be active and the fields array full


### PR DESCRIPTION
### Jira Ticket:
BRS-1198

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1198

### Description:
Changing the `fields` property of variance objects from

``
fields: [field1, field2, field3] ...
``

to 

```
fields: [{ key: field1, percentageChange: 0.23}, { key: field2, percentageChange: 0.24}, { key: field3, percentageChange: 0.25}] ...
```

Doing this as it has been requested that the exported variance report include the percentage change for each field that triggered a variance. Want to get this change in before the variance-creating API changes hit PROD so no migration is needed. 