### PR TITLE
BRS-1198 pt1:  variance record creation and export

### DIFF
--- a/__tests__/export-variance.test.js
+++ b/__tests__/export-variance.test.js
@@ -1,0 +1,161 @@
+const AWS = require("aws-sdk");
+const { DocumentClient } = require("aws-sdk/clients/dynamodb");
+const { REGION, ENDPOINT, TABLE_NAME } = require("./global/settings");
+const { PARKSLIST, SUBAREAS, VARIANCE_JOBSLIST, VARIANCE_MOCKJOB } = require("./global/data.json");
+
+const jwt = require("jsonwebtoken");
+const tokenContent = {
+  resource_access: { "attendance-and-revenue": { roles: ["sysadmin"] } },
+};
+const token = jwt.sign(tokenContent, "defaultSecret");
+
+async function setupDb() {
+  new AWS.DynamoDB({
+    region: REGION,
+    endpoint: ENDPOINT,
+  });
+  docClient = new DocumentClient({
+    region: REGION,
+    endpoint: ENDPOINT,
+    convertEmptyValues: true,
+  });
+
+  for (const park of PARKSLIST) {
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: park,
+      })
+      .promise();
+  }
+
+  for (const subarea of SUBAREAS) {
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: subarea,
+      })
+      .promise();
+  }
+
+  for (const job of VARIANCE_JOBSLIST) {
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: job,
+      })
+      .promise();
+  }
+}
+
+describe("Export Variance Report", () => {
+  const mockedUnauthenticatedUser = {
+    decodeJWT: jest.fn((event) => {
+    }),
+    resolvePermissions: jest.fn((token) => {
+      return {
+        isAdmin: false,
+        roles: [],
+        isAuthenticated: false
+      }
+    }),
+    getParkAccess: jest.fn((orcs, permissionObject) => {
+      return {};
+    })
+  };
+
+  const mockedSysadmin = {
+    decodeJWT: jest.fn((event) => {
+    }),
+    resolvePermissions: jest.fn((token) => {
+      return {
+        isAdmin: true,
+        roles: ['sysadmin'],
+        isAuthenticated: true
+      }
+    }),
+    getParkAccess: jest.fn((orcs, permissionObject) => {
+      return {};
+    })
+  };
+
+  const OLD_ENV = process.env;
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV }; // Make a copy of environment
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  beforeAll(async () => {
+    return await setupDb();
+  });
+
+  test("Handler - 403 GET Invalid Auth", async () => {
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedUnauthenticatedUser;
+    });
+    const varianceExportGET = require("../lambda/export-variance/GET/index");
+    const response = await varianceExportGET.handler({},null);
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test("Handler - 200 GET, with no jobs", async () => {
+    const dateField = "dateGenerated"
+    const event = {
+      headers: {
+        Authorization: "Bearer " + token,
+      },
+      httpMethod: "GET",
+      queryStringParameters: {
+        getJob: "true"
+      },
+    };
+
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedSysadmin;
+    });
+    const varianceExportGET = require("../lambda/export-variance/GET/index");
+    const result = await varianceExportGET.handler(event, null);
+    let body;
+    try {
+      body = JSON.parse(result.body)
+    } catch (e) {
+      body = 'fail'
+    }
+    expect(result).toEqual(
+      expect.objectContaining({
+        headers: {
+          "Access-Control-Allow-Headers":
+            "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+          "Access-Control-Allow-Methods": "OPTIONS,GET,POST",
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+        },
+        statusCode: 200,
+      }),
+    );
+    expect(body.jobObj[dateField]).toMatch(VARIANCE_JOBSLIST[0][dateField])
+  })
+
+  test("Handler - 200 GET, generate report", async () => {
+    const event = {
+      headers: {
+        Authorization: "Bearer " + token,
+      },
+      httpMethod: "GET",
+    };
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedSysadmin;
+    });
+    const varianceExportGET = require("../lambda/export-variance/GET/index"); 
+    const result = await varianceExportGET.handler(event, null)
+
+    // Returns value below even with no job
+    // Update when invokable can be called
+    expect(result.body).toBe("{\"msg\":\"Variance report export job already running\"}")
+  });
+});

--- a/__tests__/global/data.json
+++ b/__tests__/global/data.json
@@ -235,6 +235,27 @@
       "progressPercentage": 100
     }
   ],
+  "VARIANCE_JOBSLIST": [
+    {
+      "dateGenerated": "2023-01-05T22:12:49.314Z",
+      "lastSuccessfulJob": {
+        "dateGenerated": "2023-01-05T22:12:49.314Z",
+        "key": "65cad5a82897a9cbcfd251af3c769e87/A&R_Variance_Report.csv"
+      },
+      "progressDescription": "Job Complete.",
+      "progressState": "complete",
+      "sk": "65cad5a82897a9cbcfd251af3c769e87",
+      "pk": "variance-exp-job",
+      "progressPercentage": 100
+    }
+  ],
+  "VARIANCE_MOCKJOB": {
+    "sk": "VARIANCE_MOCK_JOB_ID",
+    "progressPercentage": 0,
+    "key": "MOCK_S3_KEY",
+    "progressDescription": "",
+    "lastSuccessfulJob": {}
+  },
   "MOCKJOB": {
     "sk": "MOCK_JOB_ID",
     "progressPercentage": 0,

--- a/lambda/constants.js
+++ b/lambda/constants.js
@@ -92,6 +92,15 @@ const STATE_DICTIONARY = {
   COMPLETE: 7,
 };
 
+VARIANCE_STATE_DICTIONARY = {
+  ERROR: 99,
+  FETCHING: 1,
+  FORMATTING: 2,
+  GENERATING: 3,
+  UPLOADING: 4,
+  COMPLETE: 5,
+}
+
 const CSV_SYSADMIN_SCHEMA = [
   // Shared Data
   {
@@ -726,10 +735,16 @@ const CSV_SYSADMIN_SCHEMA = [
   },
 ];
 
+VARIANCE_CSV_SCHEMA = [
+  'Bundle', 'ORCS', 'Park Name', 'Sub-area Name', 'Sub-area ID', 'Activity', 'Year', 'Month', 'Notes', 'Variances'
+]
+
 module.exports = {
   EXPORT_NOTE_KEYS,
   EXPORT_VARIANCE_CONFIG,
   EXPORT_MONTHS,
   CSV_SYSADMIN_SCHEMA,
   STATE_DICTIONARY,
+  VARIANCE_CSV_SCHEMA,
+  VARIANCE_STATE_DICTIONARY
 };

--- a/lambda/export-variance/GET/index.js
+++ b/lambda/export-variance/GET/index.js
@@ -1,0 +1,173 @@
+const AWS = require("aws-sdk");
+const s3 = new AWS.S3();
+
+const IS_OFFLINE =
+  process.env.IS_OFFLINE && process.env.IS_OFFLINE === "true" ? true : false;
+
+const options = {};
+if (IS_OFFLINE) {
+  options.region = "local-env";
+  // For local we use port 3002 because we're hitting an invokable
+  options.endpoint = "http://localhost:3002";
+}
+
+const lambda = new AWS.Lambda(options);
+
+const { logger } = require("../../logger");
+const { decodeJWT, resolvePermissions } = require("../../permissionUtil");
+const { sendResponse } = require("../../responseUtil");
+const { TABLE_NAME, dynamodb } = require("../../dynamoUtil");
+const crypto = require('crypto');
+
+const EXPORT_FUNCTION_NAME =
+  process.env.EXPORT_FUNCTION_NAME || "bcparks-ar-api-api-varianceExportInvokable";
+
+const EXPIRY_TIME = process.env.EXPORT_EXPIRY_TIME
+  ? Number(process.env.EXPORT_EXPIRY_TIME)
+  : 60 * 15; // 15 minutes
+
+exports.handler = async (event, context) => {
+  logger.info("GET: Export variances - ", event?.queryStringParameters);
+
+  // decode permissions
+  const token = await decodeJWT(event);
+  const permissionObject = resolvePermissions(token);
+
+  if (!permissionObject.isAuthenticated) {
+    return sendResponse(403, { msg: "Error: Not authenticated" }, context);
+  }
+
+  let params = event?.queryStringParameters || {};
+  params['roles'] = permissionObject.roles;
+
+  // generate a job id from params+role
+  const decodedHash = JSON.stringify(params) + JSON.stringify(permissionObject.roles);
+  const hash = crypto.createHash('md5').update(decodedHash).digest('hex');
+  const pk = "variance-exp-job";
+
+  // check for existing job
+  let existingJobQueryObj = {
+    TableName: TABLE_NAME,
+    ExpressionAttributeValues: {
+      ":pk": { S: pk },
+      ":sk": { S: hash }
+    },
+    KeyConditionExpression: "pk = :pk and sk = :sk"
+  }
+
+  let jobObj = {};
+
+  try {
+    const res = await dynamodb.query(existingJobQueryObj).promise();
+    jobObj = AWS.DynamoDB.Converter.unmarshall(res?.Items?.[0]) || null;
+  } catch (error) {
+    logger.error("Error querying for existing job: ", error);
+    return sendResponse(500, { msg: "Error querying for existing job" }, context);
+  }
+
+  if (params?.getJob) {
+    // We're trying to download an existing job
+    if (!jobObj) {
+      // Job doesn't exist.
+      return sendResponse(200, { msg: "Requested job does not exist" }, context);
+    } else if (
+      jobObj.progressState === "complete" ||
+      jobObj.progressState === "error"
+    ) {
+      // Job is not currently running. Return signed URL
+      try {
+
+        let urlKey = jobObj?.key;
+        let message = 'Job completed';
+        if (res.progressState === 'error') {
+          key = jobObj?.lastSuccessfulJob.key;
+          message = 'Job failed. Returning last successful job.';
+        }
+        let URL = "";
+        if (!process.env.IS_OFFLINE) {
+          URL = await s3.getSignedUrl("getObject", {
+            Bucket: process.env.S3_BUCKET_DATA,
+            Expires: EXPIRY_TIME,
+            Key: urlKey,
+          });
+        }
+        // send back new job object
+        delete jobObj.pk;
+        delete jobObj.sk;
+        delete jobObj.key;
+        return sendResponse(200, { msg: message, signedURL: URL, jobObj: jobObj }, context);
+      } catch (error) {
+        logger.error("Error getting signed URL: ", error);
+        return sendResponse(500, { msg: "Error getting signed URL" }, context);
+      }
+
+    } else {
+      // Job is currently running. Return latest job object
+      delete jobObj.pk;
+      delete jobObj.sk;
+      delete jobObj.key;
+      return sendResponse(200, { msg: "Job is currently running", jobObj: jobObj }, context);
+    }
+  } else {
+    // We are trying to generate a new report
+    // If there's already a completed job, we want to save this in case the new job fails
+    let lastSuccessfulJob = null;
+    if (jobObj && jobObj?.progressState === "complete" && jobObj?.key) {
+      lastSuccessfulJob = {
+        key: jobObj?.key,
+        dateGenerated: jobObj?.dateGenerated || new Date().toISOString(),
+      }
+    } else if (jobObj?.progressState === "error") {
+      lastSuccessfulJob = jobObj?.lastSuccessfulJob || {};
+    }
+
+    try {
+      // create the new job object
+      const varianceExportPutObj = {
+        TableName: TABLE_NAME,
+        ExpressionAttributeValues: {
+          ":complete": { S: "complete" },
+          ":error": { S: "error" },
+        },
+        ConditionExpression: "(attribute_not_exists(pk) AND attribute_not_exists(sk)) OR attribute_not_exists(progressState) OR progressState = :complete OR progressState = :error",
+        Item: AWS.DynamoDB.Converter.marshall({
+          pk: pk,
+          sk: hash,
+          params: params,
+          progressPercentage: 0,
+          progressDescription: "Initializing job.",
+          progressState: "Initializing",
+          lastSuccessfulJob: lastSuccessfulJob || null
+        }),
+      };
+
+      logger.debug('Creating new job:', varianceExportPutObj);
+
+      const newJob = await dynamodb.putItem(varianceExportPutObj).promise();
+      logger.debug('New job created:', newJob);
+
+      // run the export function
+      const varianceExportParams = {
+        FunctionName: EXPORT_FUNCTION_NAME,
+        InvocationType: "Event",
+        LogType: "None",
+        Payload: JSON.stringify({
+          jobId: hash,
+          params: params,
+          lastSuccessfulJob: lastSuccessfulJob
+        })
+      }
+
+      // Invoke the variance report export lambda
+      await lambda.invoke(varianceExportParams).promise();
+
+      return sendResponse(200, { msg: "Variance report export job created" }, context);
+    } catch (error) {
+      // a job already exists
+      logger.error("Error creating new job:", error);
+      return sendResponse(200, { msg: "Variance report export job already running" }, context);
+
+    }
+  }
+}
+

--- a/lambda/export-variance/invokable/index.js
+++ b/lambda/export-variance/invokable/index.js
@@ -1,0 +1,272 @@
+const { logger } = require("../../logger")
+const AWS = require('aws-sdk');
+const fs = require('fs');
+
+const { VARIANCE_CSV_SCHEMA, VARIANCE_STATE_DICTIONARY } = require("../../constants");
+const { getParks, TABLE_NAME, dynamodb, runQuery } = require("../../dynamoUtil");
+const s3 = new AWS.S3();
+
+const FILE_PATH = process.env.FILE_PATH || "./";
+const FILE_NAME = process.env.FILE_NAME || "A&R_Variance_Report";
+
+let LAST_SUCCESSFUL_JOB = {};
+let JOB_ID;
+let S3_KEY;
+let PARAMS;
+
+exports.handler = async (event, context) => {
+  logger.debug("Running export invokable: ", event);
+
+  try {
+    LAST_SUCCESSFUL_JOB = event.lastSuccessfulJob || {};
+    if (event?.jobId && event?.params?.roles) {
+      JOB_ID = event.jobId;
+      S3_KEY = JOB_ID + "/" + FILE_NAME + ".xlsx";
+      const roles = event?.params?.roles;
+      PARAMS = event?.params;
+
+      // The spreadsheet schema should not change depending on role, so it can be static
+      const schema = VARIANCE_CSV_SCHEMA;
+
+      // Get variances
+      const fiscalYearEnd = event?.params?.fiscalYearEnd;
+
+      // must provide fiscal year end
+      if (!fiscalYearEnd) {
+        throw new Error("Missing fiscal year end parameter");
+      }
+
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.FETCHING);
+
+      // collect variance records
+      const records = await getVarianceRecords(fiscalYearEnd, roles);
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.FORMATTING);
+
+      // format records for csv
+      formatRecords(records);
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.GENERATING);
+
+      // create csv
+      const csv = createCSV(records);
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.UPLOADING);
+
+      // upload csv to S3
+      await uploadToS3(csv);
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.UPLOADING);
+      
+      // success!
+      LAST_SUCCESSFUL_JOB = {
+        key: S3_KEY,
+        dateGenerated: new Date().toISOString(),
+      }
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.UPLOADING, 95);
+      await updateJobWithState(VARIANCE_STATE_DICTIONARY.COMPLETE);
+
+    }
+  } catch (error) {
+    logger.error("Error running export invokable: ", error);
+    await updateJobWithState(VARIANCE_STATE_DICTIONARY.ERROR)
+  }
+}
+
+async function updateJobWithState(state, percentageOverride = null) {
+  let percentage = null;
+  let message = '';
+  switch (state) {
+    // error
+    case 99:
+      state = 'error';
+      message = 'Job failed. Exporter encountered an error.';
+      break;
+    // fetching data
+    case 1:
+      state = 'fetching_data';
+      percentage = percentageOverride || 10;
+      message = 'Fetching data from database.';
+      break;
+    case 2:
+      state = 'formatting_records';
+      percentage = percentageOverride || 50;
+      message = 'Formatting records.';
+      break;
+    case 3:
+      state = 'generating_report';
+      percentage = percentageOverride || 60;
+      message = 'Generating report.';
+      break;
+    case 4:
+      state = 'uploading_report';
+      percentage = percentageOverride || 90;
+      message = 'Uploading report.';
+      break;
+    case 5:
+      state = 'complete';
+      percentage = percentageOverride || 100;
+      message = 'Complete.';
+      break;
+    default:
+      break;
+  }
+  let jobObj = {
+    pk: 'variance-exp-job',
+    sk: JOB_ID,
+    progressState: state,
+    progressPercentage: percentage,
+    progressDescription: message,
+    lastSuccessfulJob: LAST_SUCCESSFUL_JOB,
+    params: PARAMS,
+    dateGenerated: new Date().toISOString(),
+  }
+  try {
+    await updateJobEntry(jobObj);
+  } catch (error) {
+    throw new Error("Error updating job: " + error);
+  }
+}
+
+
+async function updateJobEntry(jobObj) {
+  const putObj = {
+    TableName: TABLE_NAME,
+    Item: AWS.DynamoDB.Converter.marshall(jobObj)
+  }
+  await dynamodb.putItem(putObj).promise();
+}
+
+async function getVarianceRecords(fiscalYearEnd, roles) {
+  // determine permissions from roles
+  const isAdmin = roles.includes('sysadmin');
+
+  // determine orcs & saids roles has access to
+  let orcsList = [];
+  let saidList = [];
+  if (isAdmin) {
+    // must check all parks.
+    const parks = await getParks();
+    orcsList = parks.map(park => park.orcs)
+  } else {
+    // must check only parks that the user has access to
+    for (const role of roles) {
+      const orcs = role.split(':')[0];
+      const said = role.split(':')[1];
+      if (!orcsList.includes(orcs)) {
+        orcsList.push(orcs);
+      }
+      if (!saidList.includes(said)) {
+        saidList.push(said);
+      }
+    }
+  }
+
+  // determine months in fiscal year
+  const dates = [];
+  for (let i = 1; i <= 12; i++) {
+    year = fiscalYearEnd;
+    if (i > 3) {
+      year -= 1;
+    }
+    dates.push(year + String(i).padStart(2, '0'))
+  }
+
+  // get all variance records
+  const varianceQueryObj = {
+    TableName: TABLE_NAME,
+    ExpressionAttributeValues: {
+    }
+  }
+
+  let varianceRecords = [];
+
+  try {
+    // cycle through parks
+    for (const orcs of orcsList) {
+      // cycle through months
+      for (const date of dates) {
+        // add to query
+        const varianceQueryObj = {
+          TableName: TABLE_NAME,
+          ExpressionAttributeValues: {
+            ':pk': { S: `variance::${orcs}::${date}` }
+          },
+          KeyConditionExpression: 'pk = :pk'
+        }
+        // get records
+        let records = await runQuery(varianceQueryObj);
+        // filter records without subarea access
+        if (!isAdmin) {
+          records = records.filter(record => {
+            const said = record?.sk?.split('::')[0];
+            return saidList.includes(said);
+          })
+        }
+        // add to array
+        if (records.length > 0) {
+          varianceRecords = varianceRecords.concat(records);
+        }
+      }
+    }
+    return varianceRecords;
+  } catch (error) {
+    throw `Error querying variance records: ${error}`;
+  }
+}
+
+function formatRecords(records) {
+  for (const record of records) {
+    // list all variances as semicolon separated string so it can be parsed later
+    if (record.fields.length > 0) {
+      let fields = [];
+      for (const field of record.fields) {
+        fields.push(String(field.key + " " + parseFloat(field.percentageChange) * 100 + "%"));
+      }
+      record['fields'] = fields.join("; ");
+    }
+    const date = record.pk.split('::')[2];
+    record['year'] = date.slice(0, 4);
+    record['month'] = date.slice(4);
+  }
+}
+
+function createCSV(records) {
+  let content = [VARIANCE_CSV_SCHEMA];
+  for (const record of records) {
+    content.push([
+      record.bundle || 'N/A',
+      record.orcs || 'N/A',
+      record.parkName || 'N/A',
+      record.subAreaName || 'N/A',
+      record.subAreaId || 'N/A',
+      record.sk.split('::')[1] || 'N/A',
+      record.year || 'N/A',
+      record.month || 'N/A',
+      record.note || '',
+      record.fields || ''
+    ])
+  }
+  let csvData = '';
+  for (const row of content) {
+    csvData += row.join(',') + '\r\n';
+  }
+  return csvData;
+}
+
+async function uploadToS3(csvData) {
+  // write file
+  const filePath = FILE_PATH + FILE_NAME + '.csv';
+  fs.writeFileSync(filePath, csvData);
+  logger.debug("File written.");
+  // get buffer
+  const buffer = fs.readFileSync(filePath);
+
+  const params = {
+    Bucket: process.env.S3_BUCKET,
+    Key: S3_KEY,
+    Body: buffer,
+  }
+
+  if (!process.env.IS_OFFLINE) {
+    await s3.putObject(params).promise();
+  }
+  logger.debug("Uploaded to S3");
+
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -162,6 +162,17 @@ functions:
           method: GET
           path: /export
           cors: true
+  varianceExportInvokable:
+    handler: lambda/export-variance/invokable/index.handler
+    timeout: 300
+  varianceExportGet:
+    handler: lambda/export-variance/GET/index.handler
+    timeout: 300
+    events:
+      - http:
+          method: GET
+          path: /export-variance
+          cors: true
 
   ###########
   # Fiscal Year End

--- a/terraform/src/main.tf
+++ b/terraform/src/main.tf
@@ -37,6 +37,7 @@ resource "aws_api_gateway_deployment" "apideploy" {
     aws_api_gateway_integration.activityRecordLockIntegration,
     aws_api_gateway_integration.activityRecordUnlockIntegration,
     aws_api_gateway_integration.exportGetIntegration,
+    aws_api_gateway_integration.varianceExportGetIntegration,
     aws_api_gateway_integration.fiscalYearEndGetIntegration,
     aws_api_gateway_integration.fiscalYearEndLockIntegration,
     aws_api_gateway_integration.fiscalYearEndUnlockIntegration,
@@ -105,6 +106,14 @@ resource "aws_iam_role_policy_attachment" "lambda_export_invoke_cloudwatch_logs"
 }
 resource "aws_iam_role_policy_attachment" "lambda_export_get_cloudwatch_logs" {
   role       = aws_iam_role.exportGetRole.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}
+resource "aws_iam_role_policy_attachment" "lambda_variance_export_invoke_cloudwatch_logs" {
+  role       = aws_iam_role.varianceExportInvokeRole.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}
+resource "aws_iam_role_policy_attachment" "lambda_variance_export_get_cloudwatch_logs" {
+  role       = aws_iam_role.varianceExportGetRole.name
   policy_arn = aws_iam_policy.lambda_logging.arn
 }
 resource "aws_iam_role_policy_attachment" "databaseReadRoleCloudWatchLogs" {

--- a/terraform/src/roles.tf
+++ b/terraform/src/roles.tf
@@ -117,9 +117,56 @@ resource "aws_iam_role" "exportInvokeRole" {
 EOF
 }
 
+resource "aws_iam_role" "varianceExportInvokeRole" {
+  name = "varianceExportInvokeRole-${random_string.postfix.result}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy" "exportInvokeRolePolicy" {
   name        = "exportInvokeRolePolicy-${random_string.postfix.result}"
   role        = aws_iam_role.exportInvokeRole.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1464440182000",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:PutItem",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "${aws_dynamodb_table.ar_table.arn}",
+                "${aws_s3_bucket.bcgov-parks-ar-assets.arn}/*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "varianceExportInvokeRolePolicy" {
+  name        = "varianceExportInvokeRolePolicy-${random_string.postfix.result}"
+  role        = aws_iam_role.varianceExportInvokeRole.id
 
   policy = <<EOF
 {
@@ -163,6 +210,25 @@ resource "aws_iam_role" "exportGetRole" {
 EOF
 }
 
+resource "aws_iam_role" "varianceExportGetRole" {
+  name = "varianceExportGetRole-${random_string.postfix.result}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy" "exportGetRolePolicy" {
   name = "exportGetRolePolicy-${random_string.postfix.result}"
   role = aws_iam_role.exportGetRole.id
@@ -183,6 +249,34 @@ resource "aws_iam_role_policy" "exportGetRolePolicy" {
         "Resource": [
           "${aws_dynamodb_table.ar_table.arn}",
           "${aws_lambda_function.exportInvokableLambda.arn}",
+          "${aws_s3_bucket.bcgov-parks-ar-assets.arn}/*"
+        ]
+      }
+  ]
+}
+  EOF
+}
+
+resource "aws_iam_role_policy" "varianceExportGetRolePolicy" {
+  name = "varianceExportGetRolePolicy-${random_string.postfix.result}"
+  role = aws_iam_role.varianceExportGetRole.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:Query",
+            "dynamodb:PutItem",
+            "lambda:InvokeAsync",
+            "lambda:InvokeFunction",
+            "s3:GetObject"
+        ],
+        "Resource": [
+          "${aws_dynamodb_table.ar_table.arn}",
+          "${aws_lambda_function.varianceExportInvokableLambda.arn}",
           "${aws_s3_bucket.bcgov-parks-ar-assets.arn}/*"
         ]
       }

--- a/terraform/src/variance-export.tf
+++ b/terraform/src/variance-export.tf
@@ -1,0 +1,147 @@
+# ============= EXPORT INVOKABLE =============
+resource "aws_lambda_function" "varianceExportInvokableLambda" {
+  function_name = "variance-export-invokable-${random_string.postfix.result}"
+
+  filename         = "artifacts/varianceExportInvokable.zip"
+  source_code_hash = filebase64sha256("artifacts/varianceExportInvokable.zip")
+
+  handler = "lambda/export-variance/invokable/index.handler"
+  runtime = "nodejs14.x"
+  publish = "true"
+
+  timeout = 900
+  memory_size = 2048
+
+  environment {
+    variables = {
+      TABLE_NAME                                = aws_dynamodb_table.ar_table.name,
+      FILE_PATH                                 = "/tmp/",
+      FILE_NAME                                 = "A&R_Variance_Report",
+      SSO_ISSUER                                = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI                               = data.aws_ssm_parameter.sso_jwksuri.value,
+      S3_BUCKET_DATA                            = aws_s3_bucket.bcgov-parks-ar-assets.id,
+      LOG_LEVEL                                 = "info"
+    }
+  }
+  role = aws_iam_role.varianceExportInvokeRole.arn
+}
+
+resource "aws_lambda_alias" "variance_export_invokable_latest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.varianceExportInvokableLambda.function_name
+  function_version = aws_lambda_function.varianceExportInvokableLambda.version
+}
+
+# ============= EXPORT GET =============
+resource "aws_lambda_function" "varianceExportGetLambda" {
+  function_name = "variance-export-get-${random_string.postfix.result}"
+
+  filename         = "artifacts/varianceExportGet.zip"
+  source_code_hash = filebase64sha256("artifacts/varianceExportGet.zip")
+
+  handler = "lambda/export-variance/GET/index.handler"
+  runtime = "nodejs14.x"
+  timeout = 30
+  publish = "true"
+
+  memory_size = 128
+
+  role = aws_iam_role.varianceExportGetRole.arn
+
+  environment {
+    variables = {
+      TABLE_NAME           = aws_dynamodb_table.ar_table.name,
+      SSO_ISSUER           = data.aws_ssm_parameter.sso_issuer.value
+      SSO_JWKSURI          = data.aws_ssm_parameter.sso_jwksuri.value,
+      S3_BUCKET_DATA       = aws_s3_bucket.bcgov-parks-ar-assets.id,
+      EXPORT_FUNCTION_NAME = aws_lambda_function.varianceExportInvokableLambda.function_name,
+      LOG_LEVEL            = "info"
+    }
+  }
+}
+
+resource "aws_lambda_alias" "variance_export_get_latest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.varianceExportGetLambda.function_name
+  function_version = aws_lambda_function.varianceExportGetLambda.version
+}
+
+resource "aws_api_gateway_integration" "varianceExportGetIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.varianceExportResource.id
+  http_method = aws_api_gateway_method.varianceExportGet.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.varianceExportGetLambda.invoke_arn
+}
+
+resource "aws_lambda_permission" "varianceExportGetPermission" {
+  statement_id  = "varianceExportGetPermissionInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.varianceExportGetLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/export-variance"
+}
+
+resource "aws_api_gateway_resource" "varianceExportResource" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
+  path_part   = "export-variance"
+}
+
+resource "aws_api_gateway_method" "varianceExportGet" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.varianceExportResource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+//CORS
+resource "aws_api_gateway_method" "variance_export_options_method" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.varianceExportResource.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "variance_export_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.varianceExportResource.id
+  http_method = aws_api_gateway_method.variance_export_options_method.http_method
+  status_code = "200"
+  response_models = {
+    "application/json" = "Empty"
+  }
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+  depends_on = [aws_api_gateway_method.variance_export_options_method]
+}
+
+resource "aws_api_gateway_integration" "variance_export_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.varianceExportResource.id
+  http_method = aws_api_gateway_method.variance_export_options_method.http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" : "{\"statusCode\": 200}"
+  }
+  depends_on = [aws_api_gateway_method.export_options_method]
+}
+
+resource "aws_api_gateway_integration_response" "variance_export_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.varianceExportResource.id
+  http_method = aws_api_gateway_method.variance_export_options_method.http_method
+
+  status_code = aws_api_gateway_method_response.variance_export_options_200.status_code
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS'",
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+  depends_on = [aws_api_gateway_method_response.variance_export_options_200]
+}


### PR DESCRIPTION
### Jira Ticket:
BRS-1198

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1198

### Description:
Part 1 - this change largely copies/reduces the code used for the main exporter. 

New endpoint:

```
.../api/export-variance
```

You must pass in a `fiscalYearEnd` query param so that the search can parse only 1 year at a time

```
.../api/export-variance?fiscalYearEnd=2024 // will get you results from 202304-202403
```
It's predicted that some of these queries could take a long time to complete, so when the endpoint is called, a job id is set up and the heavy lifting is completed by an asynchronous Lambda invokable. The job id is a md5 hash generated from the users roles and the queryParams passed in (only `fiscalYearEnd` for now). This way, like the exporter, users with the same roles & requests can download existing reports generated by previous users if they exist. You can check the status of your specific role/request job at any time by using the `getJob` query param:
```
.../api/export-variance?fiscalYearEnd=2024&getJob=true
```
