### PR TITLE
BRS-1198-2 ignore getJob boolean from job id creation

### DIFF
--- a/__tests__/global/data.json
+++ b/__tests__/global/data.json
@@ -240,11 +240,11 @@
       "dateGenerated": "2023-01-05T22:12:49.314Z",
       "lastSuccessfulJob": {
         "dateGenerated": "2023-01-05T22:12:49.314Z",
-        "key": "65cad5a82897a9cbcfd251af3c769e87/A&R_Variance_Report.csv"
+        "key": "dad2b66eca14331cb6186d181c51d08a/A&R_Variance_Report.csv"
       },
       "progressDescription": "Job Complete.",
       "progressState": "complete",
-      "sk": "65cad5a82897a9cbcfd251af3c769e87",
+      "sk": "dad2b66eca14331cb6186d181c51d08a",
       "pk": "variance-exp-job",
       "progressPercentage": 100
     }

--- a/lambda/export-variance/GET/index.js
+++ b/lambda/export-variance/GET/index.js
@@ -41,7 +41,9 @@ exports.handler = async (event, context) => {
   params['roles'] = permissionObject.roles;
 
   // generate a job id from params+role
-  const decodedHash = JSON.stringify(params) + JSON.stringify(permissionObject.roles);
+  let hashParams = {...params};
+  delete hashParams.getJob;
+  const decodedHash = JSON.stringify(hashParams) + JSON.stringify(permissionObject.roles);
   const hash = crypto.createHash('md5').update(decodedHash).digest('hex');
   const pk = "variance-exp-job";
 
@@ -67,7 +69,7 @@ exports.handler = async (event, context) => {
 
   if (params?.getJob) {
     // We're trying to download an existing job
-    if (!jobObj) {
+    if (!jobObj?.sk) {
       // Job doesn't exist.
       return sendResponse(200, { msg: "Requested job does not exist" }, context);
     } else if (


### PR DESCRIPTION
### Jira Ticket:
BRS-1198

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1198

### Description:
Minor fix to previous BRS-1198 commit - when creating the job id hash from the users roles & params, the `getJob` param was included, preventing ease of lookup by hash. The `getJob` param is now deleted before the job hash is created/searched.

This change must be merged before the front-end changes will work
