### PR TITLE
BRS-1216: variance trigger threshold now inclusive

### DIFF
--- a/lambda/activity/POST/index.js
+++ b/lambda/activity/POST/index.js
@@ -118,12 +118,12 @@ async function handleVarianceTrigger(body, lock, context) {
   return await handleActivity(body, lock, context);
 }
 
-async function deleteVariance(subAreaId, activity, date) {
+async function deleteVariance(orcs, date, subAreaId, activity) {
   const params = {
     TableName: TABLE_NAME,
     Key: {
-      pk: { S: `variance::${subAreaId}::${activity}` },
-      sk: { S: date },
+      pk: { S: `variance::${orcs}::${date}` },
+      sk: { S: `${subAreaId}::${activity}` },
     },
   };
 
@@ -191,7 +191,7 @@ async function checkVarianceTrigger(body) {
     await createVariance(orcs, date, subAreaId, activity, fields, notes, parkName, subAreaName);
   } else {
     // Attempt to delete any previous variances
-    await deleteVariance(subAreaId, activity, date);
+    await deleteVariance(orcs, date, subAreaId, activity);
   }
 }
 

--- a/lambda/varianceUtils.js
+++ b/lambda/varianceUtils.js
@@ -31,7 +31,7 @@ function calculateVariance(
 
   // Since percentage change is absolute, we can subtract from variance percentage
   // If negative, variance is triggered
-  const varianceTriggered = variancePercentage - percentageChangeAbs < 0 ? true : false;
+  const varianceTriggered = variancePercentage - percentageChangeAbs <= 0 ? true : false;
   logger.info("Variance Triggered:", varianceTriggered);
   logger.info("Variance percentageChange:", percentageChange);
   logger.info("Variance variancePercentage:", variancePercentage);


### PR DESCRIPTION
### Jira Ticket:
BRS-1216

### Jira Ticket URL:
https://bcparksdigital.atlassian.net/browse/BRS-1216

### Description:
Variance trigger is now inclusive of the +/- 20% threshold.

Before:
```
Variance triggered when: |variance percent| > 20%
```
Now:
```
Variance triggered when: |variance percent| >= 20%
```
Also fixed: Variance records are now deleted when all fields are brought within the threshold AND no notes exist on the activity record. 
