### PR TITLE
CW Alarm for nameUpdate serverless.com issue

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -228,6 +228,11 @@ functions:
   ###########
   nameUpdate:
     handler: lambda/nameUpdate/index.handler
+    package:
+      include:
+        - lambda/nameUpdate/**
+        - node_modules/**
+        - lambda/*.js
 
   ###########
   # Export


### PR DESCRIPTION
### Jira Ticket:
PDR-224

Serverless.com issue for cloudwatch alarm on `nameUpdate` - looks like this was missed on the last serverless.com updates.