### PR TITLE
AR-293: Adding migration to fix subarea roles

### DIFF
--- a/migrations/20240125103944-fixSubAreaRoles.js
+++ b/migrations/20240125103944-fixSubAreaRoles.js
@@ -1,0 +1,60 @@
+const { TABLE_NAME, getParks, dynamodb } = require('../lambda/dynamoUtil');
+
+async function fixSubAreaRoles() {
+  const parks = await getParks();
+  for (const park of parks) {
+    const subAreas = await getUnmarshalledSubAreas(park.orcs);
+    subAreas.forEach(async (subArea) => {
+      subArea.roles = {
+        L: [
+          {
+            S: 'sysadmin',
+          },
+          {
+            S: `${subArea.orcs.S}:${subArea.sk.S}`,
+          },
+        ],
+      };
+      let params = {
+        TableName: TABLE_NAME,
+        ConditionExpression: 'attribute_exists(pk) AND attribute_exists(sk)',
+        Key: {
+          pk: subArea.pk,
+          sk: subArea.sk,
+        },
+        UpdateExpression: 'set #roles = :roles',
+        ExpressionAttributeValues: {
+          ':roles': subArea.roles,
+        },
+        ExpressionAttributeNames: {
+          '#roles': 'roles',
+        },
+      };
+
+      try {
+        await dynamodb.updateItem(params).promise();
+        console.log('Subarea', subArea.sk, 'has been fixed.');
+      } catch (error) {
+        console.log('An error occured while fixing subarea', subArea.sk);
+        console.log(error);
+      }
+    });
+  }
+}
+
+async function getUnmarshalledSubAreas(orcs, includeLegacy = true) {
+  const subAreaQuery = {
+    TableName: TABLE_NAME,
+    KeyConditionExpression: 'pk = :pk',
+    ExpressionAttributeValues: {
+      ':pk': { S: `park::${orcs}` },
+    },
+  };
+  if (!includeLegacy) {
+    subAreaQuery.FilterExpression = 'isLegacy = :legacy OR attribute_not_exists(isLegacy)';
+    subAreaQuery.ExpressionAttributeValues[':legacy'] = { BOOL: false };
+  }
+  return (await dynamodb.query(subAreaQuery).promise()).Items;
+}
+
+fixSubAreaRoles();


### PR DESCRIPTION
### Jira Ticket:
AR-293

### Jira Ticket URL:
https://github.com/bcgov/bcparks-ar-admin/issues/293

### Description:
Adding migration to fix subarea roles.

There are instances in prod where subarea roles are incorrect:

- park::8306 has 1020 in its role
- park::0347 has 0347::612 in its role

The correct way to format a role is as follows:

```{orcs}:{sk}```

ie:
```8306:1020``` and ```0347:0612```

Note that leading zeros are included.


