### PR TITLE
Park roles are now List and not String Set

### DIFF
--- a/lambda/park/POST/index.js
+++ b/lambda/park/POST/index.js
@@ -35,7 +35,7 @@ exports.handler = async (event, context) => {
         orcs: { S: body.orcs },
         parkName: { S: body.parkName },
         isLegacy: { BOOL: body.isLegacy ? body.isLegacy : false },
-        roles: { SS: ["sysadmin", body.orcs] },
+        roles: { L: [{ S: 'sysadmin' }, { S: body.orcs }] },
         subAreas: { L: [] },
       },
     };

--- a/migrations/20240126140700-fixParkRoles.js
+++ b/migrations/20240126140700-fixParkRoles.js
@@ -1,0 +1,42 @@
+const { TABLE_NAME, getParks, dynamodb } = require('../lambda/dynamoUtil');
+const AWS = require('aws-sdk');
+
+async function fixSubAreaRoles() {
+  const parks = await getParks();
+  for (const park of parks) {
+    try {
+      const roles = {
+        L: [
+          {
+            S: 'sysadmin'
+          },
+          {
+            S: park.orcs
+          }
+        ]
+      }
+      let updateObj = {
+        TableName: TABLE_NAME,
+        Key: {
+          pk: { S: park.pk },
+          sk: { S: park.sk },
+        },
+        UpdateExpression: 'set #roles = :roles',
+        ExpressionAttributeValues: {
+          ':roles': roles,
+        },
+        ExpressionAttributeNames: {
+          '#roles': 'roles'
+        }
+      }
+      await dynamodb.updateItem(updateObj).promise();
+      console.log('Park', park.sk, 'has been fixed.');
+    } catch (error) {
+      console.log('An error occured while fixing park', park.sk);
+      console.log(error);
+      throw 'exiting';
+    }
+  }
+}
+
+fixSubAreaRoles();


### PR DESCRIPTION
API was creating new parks with roles as String Sets when the existing parks use Lists. This was causing some parks to not appear in the front end with non-sysadmin perms.
