### PR TITLE
PDR-255 warn if variance triggered

### DIFF
--- a/__tests__/activity.test.js
+++ b/__tests__/activity.test.js
@@ -271,7 +271,11 @@ describe("Activity Test", () => {
       pk: 'variance::0041::202301',
       fields: [{
         key: 'picnicRevenueGross',
-        percentageChange: 99.1
+        percentageChange: 99.1,
+        historicalAverage: 50,
+        yearlyAverages: {
+          '2022': 50
+        }
       }],
       resolved: false,
       subAreaId: '0087',

--- a/__tests__/variance.test.js
+++ b/__tests__/variance.test.js
@@ -250,6 +250,7 @@ describe("Variance Test", () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance([8, 8, 8], 10, 0.2);
     expect(res).toEqual({
+      averageHistoricValue: 8,
       varianceMessage: "Variance triggered: +25%",
       varianceTriggered: true,
       percentageChange: 0.25,
@@ -260,6 +261,7 @@ describe("Variance Test", () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance([8.5, 8.5, 8.5], 10.8, 0.2);
     expect(res).toEqual({
+      averageHistoricValue: 8.5,
       varianceMessage: "Variance triggered: +27%",
       varianceTriggered: true,
       percentageChange: 0.27,
@@ -270,6 +272,7 @@ describe("Variance Test", () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance([8.5, 8.5, 8.5], 0.8, 0.2);
     expect(res).toEqual({
+      averageHistoricValue: 8.5,
       varianceMessage: "Variance triggered: +91%",
       varianceTriggered: true,
       percentageChange: -0.91,
@@ -280,6 +283,7 @@ describe("Variance Test", () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance([10.2, 10.2, 10.2], 10.2, 0.25);
     expect(res).toEqual({
+      averageHistoricValue: 10.2,
       varianceMessage: "Variance triggered: -0%",
       varianceTriggered: false,
       percentageChange: 0,
@@ -290,6 +294,7 @@ describe("Variance Test", () => {
     const { calculateVariance } = require("../lambda/varianceUtils");
     const res = calculateVariance([8, 8, null], 10, 0.2);
     expect(res).toEqual({
+      averageHistoricValue: 8,
       varianceMessage: "Variance triggered: +25%",
       varianceTriggered: true,
       percentageChange: 0.25,

--- a/lambda/varianceUtils.js
+++ b/lambda/varianceUtils.js
@@ -40,6 +40,7 @@ function calculateVariance(
     varianceMessage: varianceMessage,
     varianceTriggered: varianceTriggered,
     percentageChange: +percentageChange,
+    averageHistoricValue: averageHistoricValue
   };
   logger.info("Variance return obj:", res);
   logger.info("=== Variance calulation complete ===");


### PR DESCRIPTION
Relates to PDR-255.

Updates the `activityPOST` endpoint to return a variance warning when variances are triggered instead of saving the activity record.

If `warn=true` is provided in the POST query param, the API will check to see if variances are triggered. If a variance is triggered AND no notes are provided, the activity POST is interrupted and the would-be variance object is returned, but not saved to the database. The activity record is not updated.

Inversely, if `warn=true` and notes are provided, the API will update the activity activity record. If a variance is triggered, a variance object will be created in the database but the user will not be warned.