### PR TITLE
BRS-291-13: Update deploys, makefiles; change crypto, fix cors errors

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -75,7 +75,6 @@ jobs:
       - name: SAM deploy
         env:
           STAGE: ${{ vars.AR_API_STAGE }}
-          STACK_NAME: ${{ vars.AR_API_STACK_NAME }}
           ACCOUNT_ID: ${{ vars.ACCOUNT_ID }}
           AWS_ACCOUNT_LIST: ${{ vars.AWS_ACCOUNT_LIST }}
           SSO_ISSUER: ${{ vars.SSO_ISSUER }}
@@ -86,7 +85,7 @@ jobs:
           DATA_REGISTER_NAME_ENDPOINT: ${{ secrets.DATA_REGISTER_NAME_ENDPOINT }}
           DATA_REGISTER_NAME_API_KEY: ${{ secrets.DATA_REGISTER_NAME_API_KEY }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AccountId=$ACCOUNT_ID" "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "SSOClientId=$SSO_CLIENT_ID" "SSOOrigin=$SSO_ORIGIN" "AWSAccountList=$AWS_ACCOUNT_LIST" "S3BucketData=$S3_BUCKET_DATA" "DataRegisterNameEndpoint=$DATA_REGISTER_NAME_ENDPOINT" "DataRegisterNameApiKey=$DATA_REGISTER_NAME_API_KEY"
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AccountId=$ACCOUNT_ID" "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "SSOClientId=$SSO_CLIENT_ID" "SSOOrigin=$SSO_ORIGIN" "AWSAccountList=$AWS_ACCOUNT_LIST" "S3BucketData=$S3_BUCKET_DATA" "DataRegisterNameEndpoint=$DATA_REGISTER_NAME_ENDPOINT" "DataRegisterNameApiKey=$DATA_REGISTER_NAME_API_KEY"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy_test.yaml
+++ b/.github/workflows/deploy_test.yaml
@@ -78,7 +78,6 @@ jobs:
       - name: SAM deploy
         env:
           STAGE: ${{ vars.AR_API_STAGE }}
-          STACK_NAME: ${{ vars.AR_API_STACK_NAME }}
           ACCOUNT_ID: ${{ vars.ACCOUNT_ID }}
           AWS_ACCOUNT_LIST: ${{ vars.AWS_ACCOUNT_LIST }}
           SSO_ISSUER: ${{ vars.SSO_ISSUER }}
@@ -89,7 +88,7 @@ jobs:
           DATA_REGISTER_NAME_ENDPOINT: ${{ secrets.DATA_REGISTER_NAME_ENDPOINT }}
           DATA_REGISTER_NAME_API_KEY: ${{ secrets.DATA_REGISTER_NAME_API_KEY }}
         run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AccountId=$ACCOUNT_ID" "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "SSOClientId=$SSO_CLIENT_ID" "SSOOrigin=$SSO_ORIGIN" "AWSAccountList=$AWS_ACCOUNT_LIST" "S3BucketData=$S3_BUCKET_DATA" "DataRegisterNameEndpoint=$DATA_REGISTER_NAME_ENDPOINT" "DataRegisterNameApiKey=$DATA_REGISTER_NAME_API_KEY"
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AccountId=$ACCOUNT_ID" "Stage=$STAGE" "SSOIssuerUrl=$SSO_ISSUER" "SSOJWKSUri=$SSO_JWKSURI" "SSOClientId=$SSO_CLIENT_ID" "SSOOrigin=$SSO_ORIGIN" "AWSAccountList=$AWS_ACCOUNT_LIST" "S3BucketData=$S3_BUCKET_DATA" "DataRegisterNameEndpoint=$DATA_REGISTER_NAME_ENDPOINT" "DataRegisterNameApiKey=$DATA_REGISTER_NAME_API_KEY"
 
       - shell: bash
         env:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ To simplify troubleshooting, SAM CLI has a command called `sam logs`. `sam logs`
 `NOTE`: This command works for all AWS Lambda functions; not just the ones you deploy using SAM.
 
 ```bash
-arSam$ sam logs -n ConfigGet --stack-name arSam --tail
+arSam$ sam logs -n ConfigGet --stack-name ar-api --tail
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).

--- a/arSam/handlers/activity/GET/index.js
+++ b/arSam/handlers/activity/GET/index.js
@@ -5,7 +5,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
 
   let queryObj = {

--- a/arSam/handlers/export-variance/GET/index.js
+++ b/arSam/handlers/export-variance/GET/index.js
@@ -20,7 +20,7 @@ if (IS_OFFLINE) {
 const lambda = new Lambda(options);
 
 const { runQuery, TABLE_NAME, dynamodb, sendResponse, logger } = require("/opt/baseLayer");
-const crypto = require('crypto');
+const { createHash } = require('node:crypto');
 
 const VARIANCE_EXPORT_FUNCTION_NAME =
   process.env.VARIANCE_EXPORT_FUNCTION_NAME || "ar-api-VarianceExportInvokableFunction";
@@ -34,7 +34,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
 
   try {
@@ -55,7 +55,7 @@ exports.handler = async (event, context) => {
     let hashParams = {...params};
     delete hashParams.getJob;
     const decodedHash = JSON.stringify(hashParams) + JSON.stringify(permissionObject.roles);
-    const hash = crypto.createHash('md5').update(decodedHash).digest('hex');
+    const hash = createHash('md5').update(decodedHash).digest('hex');
     const pk = "variance-exp-job";
 
     // check for existing job

--- a/arSam/handlers/export-variance/GET/package.json
+++ b/arSam/handlers/export-variance/GET/package.json
@@ -6,7 +6,6 @@
     "@aws-sdk/client-lambda": "^3.568.0",
     "@aws-sdk/client-s3": "^3.568.0",
     "@aws-sdk/util-dynamodb": "^3.614.0",
-    "@aws-sdk/s3-request-presigner": "^3.568.0",
-    "crypto": "1.0.1"
+    "@aws-sdk/s3-request-presigner": "^3.568.0"
   }
 }

--- a/arSam/handlers/export/GET/index.js
+++ b/arSam/handlers/export/GET/index.js
@@ -33,7 +33,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
   
   try {

--- a/arSam/handlers/fiscalYearEnd/GET/index.js
+++ b/arSam/handlers/fiscalYearEnd/GET/index.js
@@ -5,7 +5,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
   
   try {

--- a/arSam/handlers/park/GET/index.js
+++ b/arSam/handlers/park/GET/index.js
@@ -6,7 +6,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
 
   let queryObj = {

--- a/arSam/handlers/readConfig/index.js
+++ b/arSam/handlers/readConfig/index.js
@@ -5,7 +5,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
 
   let queryObj = {

--- a/arSam/handlers/variance/GET/index.js
+++ b/arSam/handlers/variance/GET/index.js
@@ -6,7 +6,7 @@ exports.handler = async (event, context) => {
 
   // Allow CORS
   if (event.httpMethod === 'OPTIONS') {
-    return sendResponse(200, {}, 'Success', null, context);
+    return sendResponse(200, {}, context);
   }
 
   try {

--- a/arSam/layers/baseLayer/Makefile
+++ b/arSam/layers/baseLayer/Makefile
@@ -4,7 +4,7 @@ build-BaseLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/layers/baseLayer/baseLayer.js
+++ b/arSam/layers/baseLayer/baseLayer.js
@@ -30,7 +30,7 @@ const sendResponse = function (code, data, context) {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT,DELETE'
+      'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT'
     },
     body: JSON.stringify(data)
   };

--- a/arSam/layers/constantsLayer/Makefile
+++ b/arSam/layers/constantsLayer/Makefile
@@ -4,7 +4,7 @@ build-ConstantsLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/layers/formulaLayer/Makefile
+++ b/arSam/layers/formulaLayer/Makefile
@@ -4,7 +4,7 @@ build-FormulaLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/layers/functionsLayer/Makefile
+++ b/arSam/layers/functionsLayer/Makefile
@@ -4,7 +4,7 @@ build-FunctionsLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/layers/functionsLayer/functionsLayer.js
+++ b/arSam/layers/functionsLayer/functionsLayer.js
@@ -1,10 +1,10 @@
 const { marshall } = require('@aws-sdk/util-dynamodb');
 const { dynamodb } = require("/opt/baseLayer");
-const crypto = require("crypto");
+const { createHash } = require("node:crypto");
 
 function convertRolesToMD5(roles, prefix = "") {
   const codedRoles = prefix + roles.join("-");
-  const hash = crypto.createHash("md5").update(codedRoles).digest("hex");
+  const hash = createHash("md5").update(codedRoles).digest("hex");
   return hash;
 }
 

--- a/arSam/layers/functionsLayer/nodejs/package.json
+++ b/arSam/layers/functionsLayer/nodejs/package.json
@@ -4,7 +4,6 @@
     "author": "Digitalspace <contact@digitalspace.ca>",
     "license": "MIT",
     "dependencies": {
-      "@aws-sdk/util-dynamodb": "^3.614.0",
-      "crypto": "1.0.1"
+      "@aws-sdk/util-dynamodb": "^3.614.0"
     }
   } 

--- a/arSam/layers/keycloakLayer/Makefile
+++ b/arSam/layers/keycloakLayer/Makefile
@@ -4,7 +4,7 @@ build-KeycloakLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/layers/permissionLayer/Makefile
+++ b/arSam/layers/permissionLayer/Makefile
@@ -4,7 +4,7 @@ build-PermissionLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/layers/varianceLayer/Makefile
+++ b/arSam/layers/varianceLayer/Makefile
@@ -4,7 +4,7 @@ build-VarianceLayer:
 					# remove makefile in artifacts directory
 					rm "$(ARTIFACTS_DIR)/Makefile"
 					# install dependencies in artifacts directory
-					cd nodejs && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
+					cd nodejs && yarn cache clean && yarn --update-checksums && yarn install --ignore-scripts --frozen-lockfile --modules-folder "$(ARTIFACTS_DIR)/nodejs/node_modules"
 					# symlink to node_modules folder for testing purposes
 					cd "$(ARTIFACTS_DIR)" && ln -s "$(ARTIFACTS_DIR)"/nodejs/node_modules node_modules
 					# remove package.json to avoid rebuilding when changes don't relate to dependencies

--- a/arSam/package.json
+++ b/arSam/package.json
@@ -50,7 +50,6 @@
 		"svg-captcha": "^1.4.0",
 		"webpack": "^5.91.0",
 		"winston": "^3.8.0",
-		"write-excel-file": "^1.3.16",
-		"crypto": "1.0.1"
+		"write-excel-file": "^1.3.16"
 	}
 } 

--- a/arSam/yarn.lock
+++ b/arSam/yarn.lock
@@ -2092,15 +2092,15 @@
     tslib "^2.6.2"
 
 "@smithy/core@^2.2.6":
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-2.2.7.tgz#a49fdc8cc221bd6c9cc458719e2cf2e2212c8dde"
-  integrity sha512-Wwd9QWKaYdR+n/oIqJbuwSr9lHuv7sa1e3Zu4wIToZl0sS7xapTYYqQtXP1hKKtIWz0jl8AhvOfNwkfT5jjV0w==
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-2.2.8.tgz#d1edc47584497c58aec741b0a2814cdc1db7b72c"
+  integrity sha512-1Y0XX0Ucyg0LWTfTVLWpmvSRtFRniykUl3dQ0os1sTd03mKDudR6mVyX+2ak1phwPXx2aEWMAAdW52JNi0mc3A==
   dependencies:
     "@smithy/middleware-endpoint" "^3.0.5"
-    "@smithy/middleware-retry" "^3.0.10"
+    "@smithy/middleware-retry" "^3.0.11"
     "@smithy/middleware-serde" "^3.0.3"
     "@smithy/protocol-http" "^4.0.4"
-    "@smithy/smithy-client" "^3.1.8"
+    "@smithy/smithy-client" "^3.1.9"
     "@smithy/types" "^3.3.0"
     "@smithy/util-middleware" "^3.0.3"
     tslib "^2.6.2"
@@ -2127,9 +2127,9 @@
     tslib "^2.6.2"
 
 "@smithy/eventstream-serde-browser@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.4.tgz#98d6e7ae60d297e37ee7775af2a7a8bbe574579d"
-  integrity sha512-Eo4anLZX6ltGJTZ5yJMc80gZPYYwBn44g0h7oFq6et+TYr5dUsTpIcDbz2evsOKIZhZ7zBoFWHtBXQ4QQeb5xA==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.5.tgz#3e971afd2b8a02a098af8decc4b9e3f35296d6a2"
+  integrity sha512-dEyiUYL/ekDfk+2Ra4GxV+xNnFoCmk1nuIXg+fMChFTrM2uI/1r9AdiTYzPqgb72yIv/NtAj6C3dG//1wwgakQ==
   dependencies:
     "@smithy/eventstream-serde-universal" "^3.0.4"
     "@smithy/types" "^3.3.0"
@@ -2254,15 +2254,15 @@
     "@smithy/util-middleware" "^3.0.3"
     tslib "^2.6.2"
 
-"@smithy/middleware-retry@^3.0.10", "@smithy/middleware-retry@^3.0.9":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-3.0.10.tgz#4131d86cb6cbbbd3d2fc9de971b1da701399acf1"
-  integrity sha512-+6ibpv6jpkTNJS6yErQSEjbxCWf1/jMeUSlpSlUiTYf73LGR9riSRlIrL1+JEW0eEpb6MelQ04BIc38aj8GtxQ==
+"@smithy/middleware-retry@^3.0.11", "@smithy/middleware-retry@^3.0.9":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-3.0.11.tgz#4a8137a45247233aa83707ff9da3b8ee3dfefbba"
+  integrity sha512-/TIRWmhwMpv99JCGuMhJPnH7ggk/Lah7s/uNDyr7faF02BxNsyD/fz9Tw7pgCf9tYOKgjimm2Qml1Aq1pbkt6g==
   dependencies:
     "@smithy/node-config-provider" "^3.1.4"
     "@smithy/protocol-http" "^4.0.4"
     "@smithy/service-error-classification" "^3.0.3"
-    "@smithy/smithy-client" "^3.1.8"
+    "@smithy/smithy-client" "^3.1.9"
     "@smithy/types" "^3.3.0"
     "@smithy/util-middleware" "^3.0.3"
     "@smithy/util-retry" "^3.0.3"
@@ -2367,16 +2367,16 @@
     "@smithy/util-utf8" "^3.0.0"
     tslib "^2.6.2"
 
-"@smithy/smithy-client@^3.1.7", "@smithy/smithy-client@^3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-3.1.8.tgz#75bb081f6170069ad4c7961d19ea6f69d64d7c6d"
-  integrity sha512-nUNGCa0NgvtD0eM45732EBp1H9JQITChMBegGtPRhJD00v3hiFF6tibiOihcYwP5mbp9Kui+sOCl86rDT/Ew2w==
+"@smithy/smithy-client@^3.1.7", "@smithy/smithy-client@^3.1.9":
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-3.1.9.tgz#a0d8e867165db64c2a66762df0db279d1f8029eb"
+  integrity sha512-My2RaInZ4gSwJUPMaiLR/Nk82+c4LlvqpXA+n7lonGYgCZq23Tg+/xFhgmiejJ6XPElYJysTPyV90vKyp17+1g==
   dependencies:
     "@smithy/middleware-endpoint" "^3.0.5"
     "@smithy/middleware-stack" "^3.0.3"
     "@smithy/protocol-http" "^4.0.4"
     "@smithy/types" "^3.3.0"
-    "@smithy/util-stream" "^3.1.0"
+    "@smithy/util-stream" "^3.1.1"
     tslib "^2.6.2"
 
 "@smithy/types@^3.3.0":
@@ -2442,26 +2442,26 @@
     tslib "^2.6.2"
 
 "@smithy/util-defaults-mode-browser@^3.0.9":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.10.tgz#c6c0b29e9ebee010b15e16a495c5773b67d465c0"
-  integrity sha512-WgaNxh33md2zvlD+1TSceVmM7DIy7qYMtuhOat+HYoTntsg0QTbNvoB/5DRxEwSpN84zKf9O34yqzRRtxJZgFg==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.11.tgz#c8a74369405f55d39492b9ec15458cc2fe56b783"
+  integrity sha512-O3s9DGb3bmRvEKmT8RwvSWK4A9r6svfd+MnJB+UMi9ZcCkAnoRtliulOnGF0qCMkKF9mwk2tkopBBstalPY/vg==
   dependencies:
     "@smithy/property-provider" "^3.1.3"
-    "@smithy/smithy-client" "^3.1.8"
+    "@smithy/smithy-client" "^3.1.9"
     "@smithy/types" "^3.3.0"
     bowser "^2.11.0"
     tslib "^2.6.2"
 
 "@smithy/util-defaults-mode-node@^3.0.9":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.10.tgz#393ff6ba299f22a604ccd3a0ae977eaef683df53"
-  integrity sha512-3x/pcNIFyaAEQqXc3qnQsCFLlTz/Mwsfl9ciEPU56/Dk/g1kTFjkzyLbUNJaeOo5HT01VrpJBKrBuN94qbPm9A==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.11.tgz#288f443b65554597082858c4b6624cd362a2caaa"
+  integrity sha512-qd4a9qtyOa/WY14aHHOkMafhh9z8D2QTwlcBoXMTPnEwtcY+xpe1JyFm9vya7VsB8hHsfn3XodEtwqREiu4ygQ==
   dependencies:
     "@smithy/config-resolver" "^3.0.5"
     "@smithy/credential-provider-imds" "^3.1.4"
     "@smithy/node-config-provider" "^3.1.4"
     "@smithy/property-provider" "^3.1.3"
-    "@smithy/smithy-client" "^3.1.8"
+    "@smithy/smithy-client" "^3.1.9"
     "@smithy/types" "^3.3.0"
     tslib "^2.6.2"
 
@@ -2498,10 +2498,10 @@
     "@smithy/types" "^3.3.0"
     tslib "^2.6.2"
 
-"@smithy/util-stream@^3.0.6", "@smithy/util-stream@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-3.1.0.tgz#94720dab5bda1c9b79919e644d69669ddde50091"
-  integrity sha512-QEMvyv58QIptWA8cpQPbHagJOAlrbCt3ueB9EShwdFfVMYAviXdVtksszQQq+o+dv5dalUMWUbUHUDSJgkF9xg==
+"@smithy/util-stream@^3.0.6", "@smithy/util-stream@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-3.1.1.tgz#2fffe56d9cdf70e94a7cd690e980454b1b35ad23"
+  integrity sha512-EhRnVvl3AhoHAT2rGQ5o+oSDRM/BUSMPLZZdRJZLcNVUsFAjOs4vHaPdNQivTSzRcFxf5DA4gtO46WWU2zimaw==
   dependencies:
     "@smithy/fetch-http-handler" "^3.2.2"
     "@smithy/node-http-handler" "^3.1.3"
@@ -3926,11 +3926,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
 
 d@1, d@^1.0.1, d@^1.0.2:
   version "1.0.2"
@@ -5383,9 +5378,9 @@ is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-core-module@^2.13.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.14.0.tgz#43b8ef9f46a6a08888db67b1ffd4ec9e3dfd59d1"
-  integrity sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.0.tgz#71c72ec5442ace7e76b306e9d48db361f22699ea"
+  integrity sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==
   dependencies:
     hasown "^2.0.2"
 


### PR DESCRIPTION
- Fix to CORS error from `sendResponse`, this was cropping up in the dev environment
- Update other deploys to no longer reference `stack-name`
- Fixes to `Makefiles` to also `yarn cache clear` etc. (until we're sure the dependency errors are gone)
- Update `crypto` dependency as it has been deprecated (was flashing error/warning in `sam build`)