### PR TITLE
BRS-291-16: Remove authorizer for /config, fix broken test

### DIFF
--- a/arSam/layers/baseLayer/baseLayer.js
+++ b/arSam/layers/baseLayer/baseLayer.js
@@ -30,7 +30,7 @@ const sendResponse = function (code, data, context) {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT'
+      'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT,DELETE'
     },
     body: JSON.stringify(data)
   };

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -663,13 +663,19 @@ Resources:
             Path: /config
             Method: GET
             RestApiId: !Ref ApiDeployment
+            Auth:
+              Authorizer: NONE
+              OverrideApiAuth: true
         readConfigOptions:
           Type: Api
           Properties:
             Path: /config
             Method: OPTIONS
             RestApiId: !Ref ApiDeployment
-
+            Auth:
+              Authorizer: NONE
+              OverrideApiAuth: true
+            
   SubAreaGetFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
Remove authorizer for `/config`, fix broken test