### PR TITLE
BRS-357: Separate each variance into individual cells; increase timeout on exporters

### DIFF
--- a/arSam/__tests__/settings.js
+++ b/arSam/__tests__/settings.js
@@ -1,15 +1,13 @@
-const REGION = process.env.AWS_REGION || 'local-env';
+const REGION = process.env.AWS_REGION || 'local';
 const ENDPOINT = 'http://localhost:8000';
 const TABLE_NAME = process.env.TABLE_NAME || 'ParksAr-tests';
 const CONFIG_TABLE_NAME = process.env.CONFIG_TABLE_NAME || 'ConfigAr-tests';
 const NAME_CACHE_TABLE_NAME = process.env.NAME_CACHE_TABLE_NAME || 'NameCacheAr-tests';
-
 
 module.exports = {
   REGION,
   ENDPOINT,
   TABLE_NAME,
   CONFIG_TABLE_NAME,
-  NAME_CACHE_TABLE_NAME
+  NAME_CACHE_TABLE_NAME,
 };
- 

--- a/arSam/handlers/export-variance/__tests__/export-variance.tests.js
+++ b/arSam/handlers/export-variance/__tests__/export-variance.tests.js
@@ -193,6 +193,6 @@ describe("Export Variance Report", () => {
 
     // Returns value below even with no job
     // Update when invokable can be called
-    expect(result.body).toBe("{\"msg\":\"Variance report export job already running\"}")
+    expect(result.body).toBe("{\"msg\":\"Variance report export job created\"}")
   });
 });

--- a/arSam/handlers/export/__tests__/export.test.js
+++ b/arSam/handlers/export/__tests__/export.test.js
@@ -153,7 +153,7 @@ describe("Export Report", () => {
 
     // Returns value below even with no job
     // Update when invokable can be called
-    expect(result.body).toBe("{\"status\":\"Job is already running\"}")
+    expect(result.body).toBe("{\"status\":\"Export job created\"}")
   });
 
   test("Functions - updateJobEntry", async () => {

--- a/arSam/layers/constantsLayer/constantsLayer.js
+++ b/arSam/layers/constantsLayer/constantsLayer.js
@@ -743,10 +743,51 @@ const CSV_SYSADMIN_SCHEMA = [
   },
 ];
 
-VARIANCE_CSV_SCHEMA = [
-  'Bundle', 'ORCS', 'Park Name', 'Sub-area Name', 'Sub-area ID', 'Activity', 'Year', 'Month', 'Notes', 'Variances', 'Resolved'
-]
-
+ VARIANCE_CSV_SCHEMA = [
+  'Bundle',
+  'ORCS',
+  'Park Name',
+  'Sub-area Name',
+  'Sub-area ID',
+  'Activity',
+  'Year',
+  'Month',
+  'Notes',
+  'Resolved',
+  'Backcountry Cabins - People - Adult',
+  'Backcountry Cabins - People - Youth',
+  'Backcountry Cabins - People - Family',
+  'Backcountry Cabins - Revenue Family',
+  'Backcountry Camping - People',
+  'Backcountry Camping - Gross Revenue',
+  'Boating - Boat Attendance - Nights On Dock',
+  'Boating - Boat Attendance - Nights On Bouys',
+  'Boating - Boat Attendance - Miscellaneous',
+  'Boating - Boat Revenue - Gross Revenue',
+  'Day Use - People And Vehicles - Trail Count',
+  'Day Use - People And Vehicles - Vehicle Count',
+  'Day Use - People And Vehicles - Bus Count',
+  'Day Use - Picnic Shelters - Rentals',
+  'Day Use - Picnic Shelters - People',
+  'Day Use - Picnic Shelters - Gross Revenue',
+  'Day Use - Hot Springs - People',
+  'Day Use - Hot Springs - Gross Revenue',
+  'Frontcountry Cabins - Total Attendance - Parties',
+  'Frontcountry Cabins - Gross Revenue',
+  'Frontcountry Camping - Camping Party Nights - Standard',
+  'Frontcountry Camping - Camping Party Nights - Senior',
+  'Frontcountry Camping - Camping Party Nights - Social Services Fee Exemption',
+  'Frontcountry Camping - Camping Party Nights - Long Stay',
+  'Frontcountry Camping - Camping Party Nights - Gross Revenue',
+  'Frontcountry Camping - Second Cars - Standard',
+  'Frontcountry Camping - Second Cars - Senior',
+  'Frontcountry Camping - Second Cars - Social Services Fee Exemption',
+  'Frontcountry Camping - Second Cars - Gross Revenue',
+  'Frontcountry Camping - Other Frontcountry Camping - Gross Sani',
+  'Frontcountry Camping - Other Frontcountry Camping - Electrical',
+  'Frontcountry Camping - Other Frontcountry Camping - Shower'
+];
+ 
 module.exports = {
   EXPORT_NOTE_KEYS,
   EXPORT_VARIANCE_CONFIG,
@@ -754,5 +795,6 @@ module.exports = {
   CSV_SYSADMIN_SCHEMA,
   STATE_DICTIONARY,
   VARIANCE_CSV_SCHEMA,
-  VARIANCE_STATE_DICTIONARY
+  VARIANCE_STATE_DICTIONARY,
+  VARIANCE_FIELDS
 };

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -50,7 +50,7 @@ Parameters:
     Default: 'false'
   S3BucketData:
     Type: String
-    Default: 'parks-ar-assets-tools' 
+    Default: 'parks-ar-assets-tools'
   TableNameAR:
     Type: String
     Default: 'ParksAr'
@@ -60,16 +60,16 @@ Parameters:
   TableNameConfigAR:
     Type: String
     Default: "ConfigAr"
-  DataRegisterNameEndpoint: 
+  DataRegisterNameEndpoint:
     Type: String
     Default: "defaultEndpoint"
   DataRegisterNameApiKey:
     Type: String
     Default: "defaultApiKey"
-  SSOIssuerUrl: 
+  SSOIssuerUrl:
     Type: String
     Default: "https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation"
-  SSOJWKSUri: 
+  SSOJWKSUri:
     Type: String
     Default: "https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation/protocol/openid-connect/certs"
   SSOOrigin:
@@ -256,7 +256,7 @@ Resources:
             Path: /activity/lock
             Method: POST
             RestApiId: !Ref ApiDeployment
-    
+
   ActivityPostUnlockFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -388,7 +388,7 @@ Resources:
   ExportInvokableFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Timeout: 300
+      Timeout: 900
       CodeUri: handlers/export/invokable/
       Handler: index.handler
       Runtime: nodejs20.x
@@ -455,7 +455,7 @@ Resources:
   VarianceExportInvokableFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Timeout: 300
+      Timeout: 900
       CodeUri: handlers/export-variance/invokable/
       Handler: index.handler
       Runtime: nodejs20.x
@@ -557,7 +557,7 @@ Resources:
       CodeUri: handlers/nameUpdate/
       Handler: index.handler
       Runtime: nodejs20.x
-      Timeout: 300
+      Timeout: 900
       Environment:
         Variables:
           TABLE_NAME: !Ref TableNameAR
@@ -686,7 +686,7 @@ Resources:
             Auth:
               Authorizer: NONE
               OverrideApiAuth: true
-            
+
   SubAreaGetFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -785,7 +785,7 @@ Resources:
             Path: /subArea
             Method: PUT
             RestApiId: !Ref ApiDeployment
-  
+
   VarianceGetFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -815,7 +815,7 @@ Resources:
             Path: /variance
             Method: OPTIONS
             RestApiId: !Ref ApiDeployment
-  
+
   VariancePostFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
### Ticket:
[#357](https://github.com/bcgov/bcparks-ar-admin/issues/357)

### Description:
- Update the Variance Report Export to contain columns for each variance report item
  - Take the items in EXPORT_VARIANCE_CONFIG and flatten the keys into an array
  - Use the flattened array to compare against the `record.fields`, which are the variance items found in each record
  - If the key matches a field, then we push the key to the record under their own item `record[field.key]` (as opposed to daisy chaining all the variances under `notes`).

- Fix the Variance test as the databases are now (as [#291](https://github.com/bcgov/bcparks-ar-api/issues/291)) recreated for each test, so the test will never find an existing export job i.e. `Variance report export job already running`
  
- Also, increase timeout for the exporter in [#291 ](https://github.com/bcgov/bcparks-ar-api/issues/291) as they seem to take a little longer with the V3 SDK