### PR TITLE
BRS-357: Separate each variance into individual cells, increase export timeouts

### DIFF
--- a/arSam/handlers/export/__tests__/export.test.js
+++ b/arSam/handlers/export/__tests__/export.test.js
@@ -1,61 +1,61 @@
 const { DynamoDBClient, PutItemCommand } = require('@aws-sdk/client-dynamodb');
-const { REGION, ENDPOINT } = require("../../../__tests__/settings");
-const { PARKSLIST, SUBAREAS, JOBSLIST, MOCKJOB } = require("../../../__tests__/mock_data.json");
-const { getHashedText, deleteDB, createDB } = require("../../../__tests__/setup");
+const { REGION, ENDPOINT } = require('../../../__tests__/settings');
+const { PARKSLIST, SUBAREAS, JOBSLIST, MOCKJOB } = require('../../../__tests__/mock_data.json');
+const { getHashedText, deleteDB, createDB } = require('../../../__tests__/setup');
 const { marshall } = require('@aws-sdk/util-dynamodb');
 
-const jwt = require("jsonwebtoken");
+const jwt = require('jsonwebtoken');
 const tokenContent = {
-  resource_access: { "attendance-and-revenue": { roles: ["sysadmin"] } },
+  resource_access: { 'attendance-and-revenue': { roles: ['sysadmin'] } },
 };
-const token = jwt.sign(tokenContent, "defaultSecret");
+const token = jwt.sign(tokenContent, 'defaultSecret');
 
 async function setupDb(tableName) {
   const dynamoClient = new DynamoDBClient({
     region: REGION,
-    endpoint: ENDPOINT
+    endpoint: ENDPOINT,
   });
 
   for (const park of PARKSLIST) {
     let params = {
-        TableName: tableName,
-        Item: marshall(park),
-      }
-    await dynamoClient.send(new PutItemCommand(params))
+      TableName: tableName,
+      Item: marshall(park),
+    };
+    await dynamoClient.send(new PutItemCommand(params));
   }
 
   for (const subarea of SUBAREAS) {
     let params = {
-        TableName: tableName,
-        Item: marshall(subarea),
-      }  
-    await dynamoClient.send(new PutItemCommand(params))
-    }
+      TableName: tableName,
+      Item: marshall(subarea),
+    };
+    await dynamoClient.send(new PutItemCommand(params));
+  }
 
   for (const job of JOBSLIST) {
     let params = {
-        TableName: tableName,
-        Item: marshall(job),
-    }
-    await dynamoClient.send(new PutItemCommand(params))
+      TableName: tableName,
+      Item: marshall(job),
+    };
+    await dynamoClient.send(new PutItemCommand(params));
   }
 }
 
-describe("Export Report", () => {
+describe('Export Report', () => {
   const OLD_ENV = process.env;
-  let hash
-  let TABLE_NAME
-  let NAME_CACHE_TABLE_NAME
-  let CONFIG_TABLE_NAME
-  
+  let hash;
+  let TABLE_NAME;
+  let NAME_CACHE_TABLE_NAME;
+  let CONFIG_TABLE_NAME;
+
   beforeEach(async () => {
     jest.resetModules();
     process.env = { ...OLD_ENV }; // Make a copy of environment
     hash = getHashedText(expect.getState().currentTestName);
-    process.env.TABLE_NAME = hash
+    process.env.TABLE_NAME = hash;
     TABLE_NAME = process.env.TABLE_NAME;
-    NAME_CACHE_TABLE_NAME = TABLE_NAME.concat("-nameCache");
-    CONFIG_TABLE_NAME = TABLE_NAME.concat("-config");
+    NAME_CACHE_TABLE_NAME = TABLE_NAME.concat('-nameCache');
+    CONFIG_TABLE_NAME = TABLE_NAME.concat('-config');
     await createDB(TABLE_NAME, NAME_CACHE_TABLE_NAME, CONFIG_TABLE_NAME);
     await setupDb(TABLE_NAME);
   });
@@ -64,113 +64,112 @@ describe("Export Report", () => {
     deleteDB(TABLE_NAME, NAME_CACHE_TABLE_NAME, CONFIG_TABLE_NAME);
     process.env = OLD_ENV; // Restore old environment
   });
-  
-  test("Handler - 403 GET Invalid Auth", async () => {
+
+  test('Handler - 403 GET Invalid Auth', async () => {
     const event = {
-        headers: {
-          Authorization: "Bearer " + token,
+      headers: {
+        Authorization: 'Bearer ' + token,
+      },
+      requestContext: {
+        authorizer: {
+          roles: '["public"]',
+          isAdmin: false,
+          isAuthenticated: false,
         },
-        requestContext: {
-          authorizer: {
-              roles: "[\"public\"]",
-              isAdmin: false,
-              isAuthenticated: false,
-          }
-        },
-        httpMethod: "GET",
-        queryStringParameters: {
-          getJob: "true"
-        },
+      },
+      httpMethod: 'GET',
+      queryStringParameters: {
+        getJob: 'true',
+      },
     };
-      
-    const exportGET = require("../GET/index");
+
+    const exportGET = require('../GET/index');
     const response = await exportGET.handler(event, null);
 
     expect(response.statusCode).toBe(403);
   });
 
-  test("Handler - 200 GET, with no jobs", async () => {
-    process.env.IS_OFFLINE = 'true'
-    const dateField = "dateGenerated"
+  test('Handler - 200 GET, with no jobs', async () => {
+    process.env.IS_OFFLINE = 'true';
+    const dateField = 'dateGenerated';
     const event = {
       headers: {
-        Authorization: "Bearer " + token,
+        Authorization: 'Bearer ' + token,
       },
       requestContext: {
         authorizer: {
-            roles: "[\"sysadmin\"]",
-            isAdmin: true,
-            isAuthenticated: true,
-        }
-      },
-      httpMethod: "GET",
-      queryStringParameters: {
-        getJob: "true"
-      },
-    };
-
-    const exportGET = require("../GET/index");
-    const result = await exportGET.handler(event, null);
-    let body;
-    try {
-      body = JSON.parse(result.body)
-    } catch (e) {
-      console.log("In this dumb catch")
-      body = 'fail'
-    }
-    
-    expect(result).toEqual(
-      expect.objectContaining({
-        headers: {
-          "Access-Control-Allow-Headers":
-          "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
-          "Access-Control-Allow-Methods": "OPTIONS,GET,POST,PUT,DELETE",
-          "Access-Control-Allow-Origin": "*",
-          "Content-Type": "application/json",
-        },
-        statusCode: 200,
-      }),
-    );
-    expect(body.jobObj[dateField]).toMatch(JOBSLIST[0][dateField]) 
-  })
-
-  test("Handler - 200 GET, generate report", async () => {
-    const event = {
-      headers: {
-        Authorization: "Bearer " + token,
-      },
-      requestContext: {
-        authorizer: {
-          roles: "[\"sysadmin\"]",
+          roles: '["sysadmin"]',
           isAdmin: true,
           isAuthenticated: true,
         },
       },
-      httpMethod: "GET",
+      httpMethod: 'GET',
+      queryStringParameters: {
+        getJob: 'true',
+      },
     };
-    const exportGET = require("../GET/index"); 
-    const result = await exportGET.handler(event, null)
+
+    const exportGET = require('../GET/index');
+    const result = await exportGET.handler(event, null);
+    let body;
+    try {
+      body = JSON.parse(result.body);
+    } catch (e) {
+      console.log('In this dumb catch');
+      body = 'fail';
+    }
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        headers: {
+          'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token',
+          'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT,DELETE',
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json',
+        },
+        statusCode: 200,
+      }),
+    );
+    expect(body.jobObj[dateField]).toMatch(JOBSLIST[0][dateField]);
+  });
+
+  test('Handler - 200 GET, generate report', async () => {
+    const event = {
+      headers: {
+        Authorization: 'Bearer ' + token,
+      },
+      requestContext: {
+        authorizer: {
+          roles: '["sysadmin"]',
+          isAdmin: true,
+          isAuthenticated: true,
+        },
+      },
+      httpMethod: 'GET',
+    };
+    const exportGET = require('../GET/index');
+    const result = await exportGET.handler(event, null);
 
     // Returns value below even with no job
     // Update when invokable can be called
-    expect(result.body).toBe("{\"status\":\"Job is already running\"}")
+    expect(result.body).toBe('{"status":"Job is already running"}');
   });
 
-  test("Functions - updateJobEntry", async () => {
+  test('Functions - updateJobEntry', async () => {
     const query = {
       TableName: TABLE_NAME,
-      KeyConditionExpression: "pk = :pk AND sk = :sk",
+      KeyConditionExpression: 'pk = :pk AND sk = :sk',
       ExpressionAttributeValues: {
-        ":pk": { S: "job" },
-        ":sk": {S: "MOCK_JOB_ID"}
-      }
+        ':pk': { S: 'job' },
+        ':sk': { S: 'MOCK_JOB_ID' },
+      },
     };
 
-    const exportFUNCTIONS = require("/opt/functionsLayer");
-    await exportFUNCTIONS.updateJobEntry(MOCKJOB, TABLE_NAME)
-    const utils = require("/opt/baseLayer");
-    const result = await utils.runQuery(query)
+    const exportFUNCTIONS = require('/opt/functionsLayer');
+    await exportFUNCTIONS.updateJobEntry(MOCKJOB, TABLE_NAME);
+    const utils = require('/opt/baseLayer');
+    const result = await utils.runQuery(query);
 
-    expect(result).toMatchObject([MOCKJOB])
-  })
+    expect(result).toMatchObject([MOCKJOB]);
+  });
 });

--- a/arSam/layers/constantsLayer/constantsLayer.js
+++ b/arSam/layers/constantsLayer/constantsLayer.js
@@ -743,10 +743,51 @@ const CSV_SYSADMIN_SCHEMA = [
   },
 ];
 
-VARIANCE_CSV_SCHEMA = [
-  'Bundle', 'ORCS', 'Park Name', 'Sub-area Name', 'Sub-area ID', 'Activity', 'Year', 'Month', 'Notes', 'Variances', 'Resolved'
-]
-
+ VARIANCE_CSV_SCHEMA = [
+  'Bundle',
+  'ORCS',
+  'Park Name',
+  'Sub-area Name',
+  'Sub-area ID',
+  'Activity',
+  'Year',
+  'Month',
+  'Notes',
+  'Resolved',
+  'Backcountry Cabins - People - Adult',
+  'Backcountry Cabins - People - Youth',
+  'Backcountry Cabins - People - Family',
+  'Backcountry Cabins - Revenue Family',
+  'Backcountry Camping - People',
+  'Backcountry Camping - Gross Revenue',
+  'Boating - Boat Attendance - Nights On Dock',
+  'Boating - Boat Attendance - Nights On Bouys',
+  'Boating - Boat Attendance - Miscellaneous',
+  'Boating - Boat Revenue - Gross Revenue',
+  'Day Use - People And Vehicles - Trail Count',
+  'Day Use - People And Vehicles - Vehicle Count',
+  'Day Use - People And Vehicles - Bus Count',
+  'Day Use - Picnic Shelters - Rentals',
+  'Day Use - Picnic Shelters - People',
+  'Day Use - Picnic Shelters - Gross Revenue',
+  'Day Use - Hot Springs - People',
+  'Day Use - Hot Springs - Gross Revenue',
+  'Frontcountry Cabins - Total Attendance - Parties',
+  'Frontcountry Cabins - Gross Revenue',
+  'Frontcountry Camping - Camping Party Nights - Standard',
+  'Frontcountry Camping - Camping Party Nights - Senior',
+  'Frontcountry Camping - Camping Party Nights - Social Services Fee Exemption',
+  'Frontcountry Camping - Camping Party Nights - Long Stay',
+  'Frontcountry Camping - Camping Party Nights - Gross Revenue',
+  'Frontcountry Camping - Second Cars - Standard',
+  'Frontcountry Camping - Second Cars - Senior',
+  'Frontcountry Camping - Second Cars - Social Services Fee Exemption',
+  'Frontcountry Camping - Second Cars - Gross Revenue',
+  'Frontcountry Camping - Other Frontcountry Camping - Gross Sani',
+  'Frontcountry Camping - Other Frontcountry Camping - Electrical',
+  'Frontcountry Camping - Other Frontcountry Camping - Shower'
+];
+ 
 module.exports = {
   EXPORT_NOTE_KEYS,
   EXPORT_VARIANCE_CONFIG,
@@ -754,5 +795,5 @@ module.exports = {
   CSV_SYSADMIN_SCHEMA,
   STATE_DICTIONARY,
   VARIANCE_CSV_SCHEMA,
-  VARIANCE_STATE_DICTIONARY
+  VARIANCE_STATE_DICTIONARY,
 };

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -50,7 +50,7 @@ Parameters:
     Default: 'false'
   S3BucketData:
     Type: String
-    Default: 'parks-ar-assets-tools' 
+    Default: 'parks-ar-assets-tools'
   TableNameAR:
     Type: String
     Default: 'ParksAr'
@@ -60,16 +60,16 @@ Parameters:
   TableNameConfigAR:
     Type: String
     Default: "ConfigAr"
-  DataRegisterNameEndpoint: 
+  DataRegisterNameEndpoint:
     Type: String
     Default: "defaultEndpoint"
   DataRegisterNameApiKey:
     Type: String
     Default: "defaultApiKey"
-  SSOIssuerUrl: 
+  SSOIssuerUrl:
     Type: String
     Default: "https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation"
-  SSOJWKSUri: 
+  SSOJWKSUri:
     Type: String
     Default: "https://dev.loginproxy.gov.bc.ca/auth/realms/bcparks-service-transformation/protocol/openid-connect/certs"
   SSOOrigin:
@@ -256,7 +256,7 @@ Resources:
             Path: /activity/lock
             Method: POST
             RestApiId: !Ref ApiDeployment
-    
+
   ActivityPostUnlockFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -388,7 +388,7 @@ Resources:
   ExportInvokableFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Timeout: 300
+      Timeout: 900
       CodeUri: handlers/export/invokable/
       Handler: index.handler
       Runtime: nodejs20.x
@@ -455,7 +455,7 @@ Resources:
   VarianceExportInvokableFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Timeout: 300
+      Timeout: 900
       CodeUri: handlers/export-variance/invokable/
       Handler: index.handler
       Runtime: nodejs20.x
@@ -557,7 +557,7 @@ Resources:
       CodeUri: handlers/nameUpdate/
       Handler: index.handler
       Runtime: nodejs20.x
-      Timeout: 300
+      Timeout: 900
       Environment:
         Variables:
           TABLE_NAME: !Ref TableNameAR
@@ -686,7 +686,7 @@ Resources:
             Auth:
               Authorizer: NONE
               OverrideApiAuth: true
-            
+
   SubAreaGetFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -785,7 +785,7 @@ Resources:
             Path: /subArea
             Method: PUT
             RestApiId: !Ref ApiDeployment
-  
+
   VarianceGetFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -815,7 +815,7 @@ Resources:
             Path: /variance
             Method: OPTIONS
             RestApiId: !Ref ApiDeployment
-  
+
   VariancePostFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
### Ticket:
[#357](https://github.com/bcgov/bcparks-ar-admin/issues/357)

### Description:
- Update the Variance Report Export to contain columns for each variance report item
  - Take the items in EXPORT_VARIANCE_CONFIG and flatten the keys into an array
  - Use the flattened array to compare against the `record.fields`, which are the variance items found in each record
  - If the key matches a field, then we push the key to the record under their own item `record[field.key]` (as opposed to daisy chaining all the variances under `fields`).
  
- Also, increase timeout for the exporter to fix issue from [#291 ](https://github.com/bcgov/bcparks-ar-api/issues/291) as they seem to take a little longer with the V3 SDK in prod

- Linting fixes to test files and `template.yaml`