### PR TITLE
BRS-257-2: Fix missing group camping, increase memory for invokables

### DIFF
--- a/arSam/handlers/export-variance/invokable/index.js
+++ b/arSam/handlers/export-variance/invokable/index.js
@@ -313,8 +313,16 @@ function createCSV(records) {
       record['secondCarsRevenueGross'] || '',
       record['otherRevenueGrossSani'] || '',
       record['otherRevenueElectrical'] || '',
-      record['otherRevenueShower'] || ''
-    ])
+      record['otherRevenueShower'] || '',
+      record['standardRateGroupsTotalPeopleStandard'] || '',
+      record['standardRateGroupsTotalPeopleAdults'] || '',
+      record['standardRateGroupsTotalPeopleYouth'] || '',
+      record['standardRateGroupsTotalPeopleKids'] || '',
+      record['standardRateGroupsRevenueGross'] || '',
+      record['youthRateGroupsAttendanceGroupNights'] || '',
+      record['youthRateGroupsAttendancePeople'] || '',
+      record['youthRateGroupsRevenueGross'],
+    ]);
   }
   let csvData = '';
   for (const row of content) {

--- a/arSam/layers/constantsLayer/constantsLayer.js
+++ b/arSam/layers/constantsLayer/constantsLayer.js
@@ -785,9 +785,17 @@ const CSV_SYSADMIN_SCHEMA = [
   'Frontcountry Camping - Second Cars - Gross Revenue',
   'Frontcountry Camping - Other Frontcountry Camping - Gross Sani',
   'Frontcountry Camping - Other Frontcountry Camping - Electrical',
-  'Frontcountry Camping - Other Frontcountry Camping - Shower'
+  'Frontcountry Camping - Other Frontcountry Camping - Shower',
+  'Group Camping - Standard Rate Groups - Nights',
+  'Group Camping - Standard Rate Groups - Adults',
+  'Group Camping - Standard Rate Groups - Youth',
+  'Group Camping - Standard Rate Groups - Kids',
+  'Group Camping - Standard Rate Groups - Gross Revenue',
+  'Group Camping - Youth Rate Groups - Nights',
+  'Group Camping - Youth Rate Groups - People',
+  'Group Camping - Youth Rate Groups - Gross Revenue',
 ];
- 
+
 module.exports = {
   EXPORT_NOTE_KEYS,
   EXPORT_VARIANCE_CONFIG,

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -392,6 +392,7 @@ Resources:
       CodeUri: handlers/export/invokable/
       Handler: index.handler
       Runtime: nodejs20.x
+      MemorySize: 1536
       FunctionName: !Ref ExportFunctionName
       Environment:
         Variables:
@@ -459,6 +460,7 @@ Resources:
       CodeUri: handlers/export-variance/invokable/
       Handler: index.handler
       Runtime: nodejs20.x
+      MemorySize: 1536
       FunctionName: !Ref VarianceExportFunctionName
       Environment:
         Variables:


### PR DESCRIPTION
### Ticket:
[#357](https://github.com/bcgov/bcparks-ar-admin/issues/357)

### Description:
- Add missing Group Camping constants and account for their columns in CSV generation
- Increase memory in invokables so we don't have to wait for hours (and fix timeout issues)