### PR TITLE
BRS-254-Fix: skMax Typo, null Check, and a Fix to the Notes in Missing Export

### DIFF
--- a/arSam/handlers/export-missing/invokable/index.js
+++ b/arSam/handlers/export-missing/invokable/index.js
@@ -432,7 +432,7 @@ function createCSV(missingRecords, fiscalYearEnd) {
                 // Not missing data, add empty space to that column
                 subAreaRow.push('');
               }
-              subAreaRow.push(missingRecord[bundle][park].notes || ''); // Notes
+              subAreaRow.push(`"${missingRecord[bundle][park][date].notes}"` || ''); // Notes
             }
 
             // Add these to the start of the array because we might not have subAreaName early on

--- a/arSam/layers/baseLayer/baseLayer.js
+++ b/arSam/layers/baseLayer/baseLayer.js
@@ -323,7 +323,16 @@ async function getSubAreas(orcs, includeLegacy = true) {
 // pass the full subarea object.
 // pass filter = false to look for every possible activity
 // includeLegacy = false will only return records that are not marked as legacy.
-async function getRecords(subArea, bundle, section, region, filter = true, includeLegacy = true, skMin = null, skMax = null) {
+async function getRecords(
+  subArea,
+  bundle,
+  section,
+  region,
+  filter = true,
+  includeLegacy = true,
+  skMin = 'null',
+  skMax = 'null'
+) {
   let records = [];
   let filteredActivityList = RECORD_ACTIVITY_LIST;
   if (filter && subArea.activities) {
@@ -338,14 +347,14 @@ async function getRecords(subArea, bundle, section, region, filter = true, inclu
       }
     };
     //if exported with date range
-    if (skMin && skMax) {
-      skMin = skMin.replace("-","");
-      skMin = skMin.replace("-","");
-      
+    if (skMin !== 'null' && skMax !== 'null') {
+      skMin = skMin.replace('-', '');
+      skMax = skMax.replace('-', '');
+
       recordQuery.KeyConditionExpression += ` AND sk BETWEEN :skMin AND :skMax`;
       recordQuery.ExpressionAttributeValues[':skMin'] = { S: skMin };
       recordQuery.ExpressionAttributeValues[':skMax'] = { S: skMax };
-    };
+    }
     if (!includeLegacy) {
       recordQuery.FilterExpression = 'isLegacy = :legacy OR attribute_not_exists(isLegacy)';
       recordQuery.ExpressionAttributeValues[':legacy'] = { BOOL: false };


### PR DESCRIPTION
### Ticket:
BRS-254

### Ticket URL:
[#254](https://github.com/bcgov/bcparks-ar-admin/issues/254)

### Description:
- Fixed an issue with the download after "Generate report" is clicked. Now looks for the string 'null' as it is passed from the event. Also fixed a typo where `skMax` wasn't having its hyphen replaced before constructing the query, leading to an error.
- Fixed an issue with the notes in the Null/Missing Export as mentioned [here](https://github.com/bcgov/bcparks-ar-api/issues/377#issuecomment-2505184502)

