### PR TITLE
BRS-389 - Implement Winter Camping Data Fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ terraform/sandbox/artifacts/
 .env
 terraform/tools/.terraform.lock.hcl
 terraform/tools/.terragrunt-cache/
+.DS_Store
 
 # AWS SAM Template vars.json for Environment variables
 *vars.json

--- a/arSam/handlers/export/invokable/index.js
+++ b/arSam/handlers/export/invokable/index.js
@@ -219,6 +219,8 @@ async function modifyReportForCSV(report) {
       report.calc_frontCountryCamping_frontCountryCamping_campingPartyNights_totalNights =
         frontcountryCampingPartyAttendance(
           [
+            report.winterCampingPartyNightsAttendanceStandard,
+            report.winterCampingPartyNightsAttendanceSocial,
             report.campingPartyNightsAttendanceStandard,
             report.campingPartyNightsAttendanceSenior,
             report.campingPartyNightsAttendanceSocial,
@@ -229,6 +231,8 @@ async function modifyReportForCSV(report) {
       report.calc_frontCountryCamping_frontCountryCamping_campingPartyNights_totalAttendance =
         frontcountryCampingPartyAttendance(
           [
+            report.winterCampingPartyNightsAttendanceStandard,
+            report.winterCampingPartyNightsAttendanceSocial,
             report.campingPartyNightsAttendanceStandard,
             report.campingPartyNightsAttendanceSenior,
             report.campingPartyNightsAttendanceSocial,

--- a/arSam/layers/constantsLayer/__tests__/constantsLayer.test.js
+++ b/arSam/layers/constantsLayer/__tests__/constantsLayer.test.js
@@ -9,7 +9,7 @@ describe("Constants Test", () => {
   
       const constants = require("../constantsLayer");
       // Checks to ensure the value functions returns the data we pass through to it based on the attribute.
-      expect(constants.CSV_SYSADMIN_SCHEMA.length).toEqual(96);
+      expect(constants.CSV_SYSADMIN_SCHEMA.length).toEqual(98);
       for(const row of constants.CSV_SYSADMIN_SCHEMA) {
         expect(row.value({
           region: 1,
@@ -22,6 +22,8 @@ describe("Constants Test", () => {
           year: 1,
           fiscalYear: 1,
           month: 1,
+          winterCampingPartyNightsAttendanceStandard: 1,
+          winterCampingPartyNightsAttendanceSocial: 1,
           campingPartyNightsAttendanceStandard: 1,
           campingPartyNightsAttendanceSenior: 1,
           campingPartyNightsAttendanceSocial: 1,

--- a/arSam/layers/constantsLayer/constantsLayer.js
+++ b/arSam/layers/constantsLayer/constantsLayer.js
@@ -10,6 +10,8 @@ const EXPORT_NOTE_KEYS = {
 
 const EXPORT_VARIANCE_CONFIG = {
   'Frontcountry Camping': {
+    winterCampingPartyNightsAttendanceStandard: 0.2,
+    winterCampingPartyNightsAttendanceSocial: 0.2,
     campingPartyNightsAttendanceStandard: 0.2,
     campingPartyNightsAttendanceSenior: 0.2,
     campingPartyNightsAttendanceSocial: 0.2,
@@ -178,6 +180,19 @@ const CSV_SYSADMIN_SCHEMA = [
     type: Number,
     width: 63,
     value: (report) => report.campingPartyNightsAttendanceLongStay,
+  },
+  // Frontcountry Camping - Camping Party Nights - Winter
+  {
+    column: 'Camping Party Nights - Winter - Standard',
+    type: Number,
+    width: 63,
+    value: (report) => report.winterCampingPartyNightsAttendanceStandard,
+  },
+  {
+    column: 'Camping Party Nights - Winter - SSCFE',
+    type: Number,
+    width: 63,
+    value: (report) => report.winterCampingPartyNightsAttendanceSocial,
   },
   {
     column: 'Frontcountry Camping - Camping Party Nights',

--- a/arSam/layers/formulaLayer/formulaLayer.js
+++ b/arSam/layers/formulaLayer/formulaLayer.js
@@ -89,7 +89,7 @@ function formatTotalWithModifier(arr, mod) {
 }
 
 function frontcountryCampingPartyAttendance(attendances, modifier) {
-  let formula = `Total attendance = (Standard + Senior + SSFE + Long stay)`;
+  let formula = `Total attendance = (Winter Standard + Winter SSCFE + Standard + Senior + SSCFE + Long stay)`;
   if (modifier) {
     formula += ` x ${modifier}`;
   }
@@ -102,7 +102,7 @@ function frontcountryCampingPartyAttendance(attendances, modifier) {
 function frontcountryCampingSecondCarAttendance(attendances) {
   return {
     result: formatTotalWithModifier(attendances),
-    formula: `Total attendance = (Standard + Senior + SSFE)`,
+    formula: `Total attendance = (Standard + Senior + SSCFE)`,
   };
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -172,6 +172,8 @@ Each activity type will have its own different `[activitySpecificFields]`.
 ### Frontcountry Camping Activity Record - Specific Fields
 ```js
 {
+  winterCampingPartyNightsAttendanceStandard: <number>,
+  winterCampingPartyNightsAttendanceSocial: <number>,
   campingPartyNightsAttendanceLongStay: <number>,
   campingPartyNightsAttendanceSenior: <number>,
   campingPartyNightsAttendanceSocial: <number>,

--- a/docs/data_model.json
+++ b/docs/data_model.json
@@ -199,6 +199,14 @@
           "AttributeType": "N"
         },
         {
+          "AttributeName": "winterCampingPartyNightsAttendanceStandard",
+          "AttributeType": "N"
+        },
+        {
+          "AttributeName": "winterCampingPartyNightsAttendanceSocial",
+          "AttributeType": "N"
+        },
+        {
           "AttributeName": "campingPartyNightsAttendanceSenior",
           "AttributeType": "N"
         },


### PR DESCRIPTION
### Ticket:
BRS-389

### Ticket URL:
[#389](https://github.com/bcgov/bcparks-ar-admin/issues/389)

### Description:
- `Winter standard` and `Winter SSCFE` now accepted data points in A&R
- Add Winter Camping data fields to attendance calculation and export fields