### PR TITLE
AR-427-2 Adding regions GET endpoint

### DIFF
--- a/arSam/__tests__/mock_data.json
+++ b/arSam/__tests__/mock_data.json
@@ -284,5 +284,36 @@
       "key": "MOCK_S3_KEY",
       "progressDescription": "",
       "lastSuccessfulJob": {}
+    },
+    "MOCK_REGION": {
+      "sk": "MOCK_REGION_ID",
+      "pk": "region",
+      "schema": "region",
+      "displayName": "Mock Region",
+      "lastUpdated": "2025-03-07T00:00:00.000Z"
+    },
+    "MOCK_SECTION": {
+      "sk": "MOCK_SECTION_ID",
+      "pk": "section::MOCK_REGION_ID",
+      "schema": "section",
+      "displayName": "Mock Section",
+      "regionId": "MOCK_REGION_ID",
+      "lastUpdated": "2025-03-07T00:00:00.000Z"
+    },
+    "MOCK_MANAGEMENT_AREA": {
+      "sk": "MOCK_MANAGEMENT_AREA_ID",
+      "pk": "managementArea::MOCK_REGION_ID::MOCK_SECTION_ID",
+      "schema": "managementArea",
+      "displayName": "Mock Management Area",
+      "regionId": "MOCK_REGION_ID",
+      "sectionId": "MOCK_SECTION_ID",
+      "lastUpdated": "2025-03-07T00:00:00.000Z"
+    },
+    "MOCK_BUNDLE": {
+      "sk": "MOCK_BUNDLE_ID",
+      "pk": "bundle",
+      "schema": "bundle",
+      "displayName": "Mock Bundle",
+      "lastUpdated": "2025-03-07T00:00:00.000Z"
     }
   }

--- a/arSam/handlers/bundle/GET/index.js
+++ b/arSam/handlers/bundle/GET/index.js
@@ -1,0 +1,1 @@
+// Bundle getter

--- a/arSam/handlers/region/GET/index.js
+++ b/arSam/handlers/region/GET/index.js
@@ -1,0 +1,89 @@
+
+const { runQuery, TABLE_NAME, sendResponse, logger } = require("/opt/baseLayer");
+const { roleFilter } = require("/opt/permissionLayer");
+
+exports.handler = async (event, context) => {
+  logger.info("GET: Region");
+
+  // Allow CORS
+  if (event.httpMethod === 'OPTIONS') {
+    return sendResponse(200, {}, context);
+  }
+
+  let regionId = event?.queryStringParameters?.regionId || null;
+
+  try {
+    let permissionObject = event?.requestContext?.authorizer;
+    permissionObject.roles = JSON.parse(permissionObject?.roles);
+    permissionObject.isAdmin = JSON.parse(permissionObject?.isAdmin || false);
+    permissionObject.isAuthenticated = JSON.parse(permissionObject?.isAuthenticated || false);
+
+    if (!permissionObject.isAuthenticated) {
+      logger.info("**NOT AUTHENTICATED, PUBLIC**");
+      return sendResponse(403, { msg: "Error: UnAuthenticated." }, context);
+    }
+
+    let response = {};
+
+    if (regionId) {
+      // Get a specific region, and build the subsequent section and management area hierarchy.
+      // Can break this out later into their own endpoints if needed, but for the purposes of AR-427, we'll just do it all here.
+
+      // Get region
+      let regionQuery = {
+        TableName: TABLE_NAME,
+        KeyConditionExpression: "pk = :pk AND sk = :sk",
+        ExpressionAttributeValues: {
+          ":pk": { S: "region" },
+          ":sk": { S: regionId },
+        },
+      };
+
+      let regionData = await runQuery(regionQuery, true);
+      response = regionData.data[0];
+
+      // Get sections
+      let sectionQuery = {
+        TableName: TABLE_NAME,
+        KeyConditionExpression: "pk = :pk",
+        ExpressionAttributeValues: {
+          ":pk": { S: `section::${regionId}` },
+        },
+      };
+
+      let sectionData = await runQuery(sectionQuery, true);
+      response["sections"] = sectionData.data;
+
+      // Get management areas
+      for (const section of response?.sections) {
+        let managementAreaQuery = {
+          TableName: TABLE_NAME,
+          KeyConditionExpression: "pk = :pk",
+          ExpressionAttributeValues: {
+            ":pk": { S: `managementArea::${regionId}::${section.sk}` },
+          },
+        };
+
+        let managementAreaData = await runQuery(managementAreaQuery, true);
+        // find the section in the response object and add the management areas
+        let sectionIndex = response.sections.indexOf(section);
+        response.sections[sectionIndex]["managementAreas"] = managementAreaData.data;
+      }
+    } else {
+      // Get a list of regions
+      let regionQuery = {
+        TableName: TABLE_NAME,
+        KeyConditionExpression: "pk = :pk",
+        ExpressionAttributeValues: {
+          ":pk": { S: "region" },
+        },
+      };
+
+      let regionData = await runQuery(regionQuery, true);
+      response = regionData.data;
+    }
+    return sendResponse(200, response, context);
+  } catch (error) {
+    return sendResponse(500, { msg: "Error: Internal Server Error." }, context);
+  }
+};

--- a/arSam/handlers/region/__tests__/region.test.js
+++ b/arSam/handlers/region/__tests__/region.test.js
@@ -1,0 +1,134 @@
+const { DynamoDBClient, PutItemCommand, GetItemCommand } = require('@aws-sdk/client-dynamodb');
+const { REGION, ENDPOINT } = require("../../../__tests__/settings");
+const { MOCK_REGION, MOCK_SECTION, MOCK_MANAGEMENT_AREA } = require("../../../__tests__/mock_data.json");
+const { getHashedText, deleteDB, createDB } = require("../../../__tests__/setup");
+const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
+
+const jwt = require("jsonwebtoken");
+const tokenContent = {
+  resource_access: { "attendance-and-revenue": { roles: ["sysadmin"] } },
+};
+const token = jwt.sign(tokenContent, "defaultSecret");
+
+
+async function setupDb(TABLE_NAME) {
+  const dynamoClient = new DynamoDBClient({ region: REGION, endpoint: ENDPOINT });
+  for (const dataItem of [MOCK_REGION, MOCK_SECTION, MOCK_MANAGEMENT_AREA]) {
+    await dynamoClient.send(new PutItemCommand({
+      TableName: TABLE_NAME,
+      Item: marshall(dataItem)
+    }));
+  }
+}
+
+describe("Region Test", () => {
+  const mockKeycloakRoles = {
+    createKeycloakRole: jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        id: '123',
+        name: 'test-role',
+      })
+    )
+  };
+
+  const OLD_ENV = process.env;
+  let hash;
+  let TABLE_NAME;
+  let NAME_CACHE_TABLE_NAME;
+  let CONFIG_TABLE_NAME;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV }; // Make a copy of environment
+    hash = getHashedText(expect.getState().currentTestName);
+    process.env.TABLE_NAME = hash;
+    TABLE_NAME = process.env.TABLE_NAME;
+    NAME_CACHE_TABLE_NAME = TABLE_NAME.concat("-nameCache");
+    CONFIG_TABLE_NAME = TABLE_NAME.concat("-config");
+    process.env.NAME_CACHE_TABLE_NAME = NAME_CACHE_TABLE_NAME;
+    process.env.CONFIG_TABLE_NAME = CONFIG_TABLE_NAME;
+    process.env.TABLE_NAME = TABLE_NAME;
+    await createDB(TABLE_NAME, NAME_CACHE_TABLE_NAME, CONFIG_TABLE_NAME);
+    await setupDb(TABLE_NAME);
+  }, 20000);
+
+  afterEach(async () => {
+    await deleteDB(TABLE_NAME, NAME_CACHE_TABLE_NAME, CONFIG_TABLE_NAME);
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test("Handler 403 - Unauthenticated", async () => {
+    const regionsGet = require('../GET/index').handler;
+
+    const response = await regionsGet({
+      headers: {
+        Authorization: "None",
+      },
+      requestContext: {
+        authorizer: {
+          roles: "[\"sysadmin\"]",
+          isAdmin: false,
+          isAuthenticated: false,
+        },
+      },
+    },
+      null
+    );
+    expect(response.statusCode).toEqual(403);
+  });
+
+  test("Handler - 200, Return list of regions", async () => {
+    jest.mock('/opt/keycloakLayer', () => {
+      return mockKeycloakRoles;
+    });
+
+    const regionsGet = require('../GET/index').handler;
+
+    const response = await regionsGet({
+      headers: {
+        Authorization: "Bearer " + token,
+      },
+      requestContext: {
+        authorizer: {
+          roles: "[\"sysadmin\"]",
+          isAdmin: true,
+          isAuthenticated: true,
+        },
+      },
+    },
+      null
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body.length).toBeGreaterThan(0);
+  });
+
+  test("Handler - 200, Return region with details", async () => {
+    jest.mock('/opt/keycloakLayer', () => {
+      return mockKeycloakRoles;
+    });
+
+    const regionsGet = require('../GET/index').handler;
+
+    const response = await regionsGet({
+      headers: {
+        Authorization: "Bearer " + token,
+      },
+      queryStringParameters: {
+        regionId: MOCK_REGION.sk
+      },
+      requestContext: {
+        authorizer: {
+          roles: "[\"sysadmin\"]",
+          isAdmin: true,
+          isAuthenticated: true,
+        },
+      },
+    },
+      null
+    );
+    expect(response.statusCode).toEqual(200);
+    const body = JSON.parse(response.body);
+    expect(body.sections.length).toBeGreaterThan(0);
+    expect(body.sections[0].managementAreas.length).toBeGreaterThan(0);
+  });
+});

--- a/arSam/package.json
+++ b/arSam/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"start": "sam local start-api --env-vars vars.json --debug",
+		"start": "sam local start-api --env-vars vars.json --warm-containers LAZY",
 		"start-full": "npm run build && npm run start",
 		"build": "sam build",
 		"test": "npm run build && jest --coverage"

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -326,6 +326,37 @@ Resources:
             Method: PUT
             RestApiId: !Ref ApiDeployment
 
+
+  BundlesGetFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/bundles/GET
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref TableNameAR
+          LOG_LEVEL: info
+      Layers:
+          - !Ref BaseLayer
+          - !Ref PermissionLayer
+      Policies:
+          - DynamoDBCrudPolicy:
+              TableName: !Ref TableNameAR
+      Events:
+        bundlesGet:
+          Type: Api
+          Properties:
+            Path: /bundles
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+        bundlesOptions:
+          Type: Api
+          Properties:
+            Path: /bundles
+            Method: OPTIONS
+            RestApiId: !Ref ApiDeployment
+
   CloudwatchAlarmFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -757,6 +788,36 @@ Resources:
             Auth:
               Authorizer: NONE
               OverrideApiAuth: true
+
+  RegionsGetFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers/region/GET
+      Handler: index.handler
+      Runtime: nodejs20.x
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref TableNameAR
+          LOG_LEVEL: info
+      Layers:
+          - !Ref BaseLayer
+          - !Ref PermissionLayer
+      Policies:
+          - DynamoDBCrudPolicy:
+              TableName: !Ref TableNameAR
+      Events:
+        regionsGet:
+          Type: Api
+          Properties:
+            Path: /regions
+            Method: GET
+            RestApiId: !Ref ApiDeployment
+        regionsOptions:
+          Type: Api
+          Properties:
+            Path: /regions
+            Method: OPTIONS
+            RestApiId: !Ref ApiDeployment
 
   SubAreaGetFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Relates to [#427](https://github.com/bcgov/bcparks-ar-admin/issues/427)

Adding regions GET endpoint.

### Get list of regions:
```
GET .../api/regions
```
Returns all regions in the database.

### Get specific region and the sections/managementAreas it contains
```
GET .../api/regions?regionId=<regionId>
```
Add `regionId` as queryStringParameter to get specific region.