### PR TITLE
NOBUG: fixing bundle path

### DIFF
--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -330,7 +330,7 @@ Resources:
   BundlesGetFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: handlers/bundles/GET
+      CodeUri: handlers/bundle/GET
       Handler: index.handler
       Runtime: nodejs20.x
       Environment:


### PR DESCRIPTION
Mislabeled path in template file is breaking the build.