### PR TITLE
AR-427-4 Adding OPTIONS handling method to Subarea GET

### DIFF
--- a/arSam/handlers/subArea/GET/index.js
+++ b/arSam/handlers/subArea/GET/index.js
@@ -1,8 +1,12 @@
 // TODO: Decouple subArea get from park get endpoint.
-const { logger } = require("/opt/baseLayer");
+const { logger, sendResponse } = require("/opt/baseLayer");
 
 exports.handler = async (event, context) => {
   logger.debug("Subarea get:", event);
+
+  if (event.httpMethod === 'OPTIONS') {
+    return sendResponse(200, {}, context);
+  }
+
   return sendResponse(501, { msg: "Error: Not implemented." }, context);
 };
-   

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -330,7 +330,7 @@ Resources:
   BundlesGetFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: handlers/bundles/GET
+      CodeUri: handlers/bundle/GET
       Handler: index.handler
       Runtime: nodejs20.x
       Environment:


### PR DESCRIPTION
Relates to https://github.com/bcgov/bcparks-ar-admin/issues/427

Subarea GET was never implemented (returns 501). Because of this, OPTIONS preflight on subarea PUT was borking.

Added OPTIONS clause to GET endpoint. Seems to have fixed the issue.