### PR TITLE
AR-367: Use config object exclusively to get new activity object information.

### DIFF
--- a/arSam/handlers/activity/POST/index.js
+++ b/arSam/handlers/activity/POST/index.js
@@ -1,5 +1,5 @@
 const { DateTime } = require('luxon');
-const { 
+const {
   dynamoClient,
   PutItemCommand,
   DeleteItemCommand,
@@ -40,7 +40,7 @@ async function main(event, context, lock = null) {
     permissionObject.roles = JSON.parse(permissionObject?.roles);
     permissionObject.isAdmin = JSON.parse(permissionObject?.isAdmin || false);
     permissionObject.isAuthenticated = JSON.parse(permissionObject?.isAuthenticated || false);
-       
+
     if (!permissionObject.isAuthenticated) {
       logger.info("**NOT AUTHENTICATED, PUBLIC**");
       return sendResponse(403, { msg: "Error: UnAuthenticated." }, context);
@@ -360,13 +360,15 @@ async function handleActivity(body, lock = false, context) {
       KeyConditionExpression: 'pk =:pk AND sk =:sk',
     };
     const configData = (await runQuery(configObj))[0];
-    if (!configData?.orcs || !configData?.parkName) {
+    if (!configData?.orcs || !configData?.parkName || !configData?.subAreaName) {
       throw 'Malformed config object';
     }
+
     body['config'] = configData;
-    body['orcs'] = body['orcs'] ? body['orcs'] : configData.orcs;
-    body['parkName'] = body['parkName'] ? body['parkName'] : configData.parkName;
-    body['subAreaName'] = body['subAreaName'] ? body['subAreaName'] : configData.subAreaName;
+    // We should be using the config data for these fields. Do not allow override if included in body.
+    body['orcs'] =  configData.orcs;
+    body['parkName'] =  configData.parkName;
+    body['subAreaName'] = configData.subAreaName;
 
     body['pk'] = pk;
 

--- a/arSam/template.yaml
+++ b/arSam/template.yaml
@@ -330,7 +330,7 @@ Resources:
   BundlesGetFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: handlers/bundles/GET
+      CodeUri: handlers/bundle/GET
       Handler: index.handler
       Runtime: nodejs20.x
       Environment:


### PR DESCRIPTION
Relates to https://github.com/bcgov/bcparks-ar-admin/issues/397

Before this change, data in the POST body for POST `/activity` would be used to determine certain properties of the activity: `orcs`, `parkName`, `subareaName`. This change ensures that this information is pulled from the config object instead.

See related ticket for an example of this bug surfacing. 

